### PR TITLE
Fix SSL/TLS hostname-not-valid error

### DIFF
--- a/src/com/zulip/android/HTTPRequest.java
+++ b/src/com/zulip/android/HTTPRequest.java
@@ -1,137 +1,150 @@
 package com.zulip.android;
 
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.NameValuePair;
-import org.apache.http.StatusLine;
 import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.params.HttpConnectionParams;
 
-import android.net.http.AndroidHttpClient;
 import android.os.AsyncTask;
 import android.util.Base64;
 import android.util.Log;
 
+import javax.net.ssl.HttpsURLConnection;
+
 /** Simplified HTTP request API */
 public class HTTPRequest {
     ZulipApp app;
-    List<NameValuePair> nameValuePairs;
-    HttpRequestBase request;
-    HttpResponse response;
+    HashMap<String, String> postDataParams;
+    HttpURLConnection conn;
     volatile boolean aborting = false;
 
     HTTPRequest(ZulipApp app) {
-        nameValuePairs = new ArrayList<NameValuePair>();
+        postDataParams = new HashMap<>();
         this.app = app;
     }
 
     public void setProperty(String key, String value) {
-        this.nameValuePairs.add(new BasicNameValuePair(key, value));
+        this.postDataParams.put(key, value);
     }
 
     public void clearProperties() {
-        this.nameValuePairs.clear();
+        this.postDataParams.clear();
     }
 
     public void abort() {
         aborting = true;
-        if (request != null) {
+        if (conn != null) {
             (new AsyncTask<Void, Void, Void>() {
                 @Override
                 protected Void doInBackground(Void... voids) {
-                    request.abort();
+                    conn.disconnect();
                     return null;
                 }
             }).execute();
         }
     }
 
-    // Java doesn't support a request body on DELETE requests, but RFC2616 does
-    // not prohibit it.
-    class HttpDeleteWithReq extends HttpPost {
-        HttpDeleteWithReq(String url) {
-            super(url);
+    private String getPostDataString(HashMap<String, String> params) throws UnsupportedEncodingException {
+        StringBuilder result = new StringBuilder();
+        boolean first = true;
+        for(Map.Entry<String, String> entry : params.entrySet()){
+            if (first)
+                first = false;
+            else
+                result.append("&");
+
+            result.append(URLEncoder.encode(entry.getKey(), "UTF-8"));
+            result.append("=");
+            if(entry.getValue() != null) {
+                result.append(URLEncoder.encode(entry.getValue(), "UTF-8"));
+            }
         }
 
-        @Override
-        public String getMethod() {
-            return "DELETE";
-        }
+        return result.toString();
     }
 
     String execute(String method, String path) throws IOException {
-        AndroidHttpClient httpclient = AndroidHttpClient.newInstance(app
-                .getUserAgent());
-
-        String responseString = null;
+        String responseString = "<empty>";
         try {
-            String url = app.getServerURI() + path;
-            nameValuePairs.add(new BasicNameValuePair("client", "Android"));
+            URL url = new URL(app.getServerURI() + path);
+            this.setProperty("client", "Android");
+            String authstr = this.app.getEmail() + ":" + this.app.getApiKey();
 
-            if (method.equals("POST")) {
-                request = new HttpPost(url);
-            } else if (method.equals("PUT")) {
-                request = new HttpPut(url);
-            } else if (method.equals("DELETE")) {
-                request = new HttpDeleteWithReq(url);
-            } else if (method.equals("GET")) {
-                request = new HttpGet(url + "?"
-                        + URLEncodedUtils.format(nameValuePairs, "utf-8"));
+            if (!method.equals("POST") && !method.equals("DELETE") &&
+                    !method.equals("PUT") && !method.equals("GET")){
+                throw new IOException("Wrong HTTP method.");
             }
+
+            if (method.equals("GET")) {
+                url = new URL(app.getServerURI() + path + "?" + getPostDataString(this.postDataParams));
+            }
+
+            conn = (HttpsURLConnection) url.openConnection();
+            conn.setRequestMethod(method);
+            conn.setRequestProperty("Authorization", "Basic "
+                    + Base64.encodeToString(authstr.getBytes(), Base64.NO_WRAP));
+            conn.setRequestProperty("User-Agent", app.getUserAgent());
+            conn.setUseCaches(false);
 
             if (!method.equals("GET")) {
-                ((HttpEntityEnclosingRequestBase) request)
-                        .setEntity(new UrlEncodedFormEntity(nameValuePairs,
-                                "UTF-8"));
+                conn.setDoInput(true);
+                conn.setDoOutput(true);
+                DataOutputStream request = new DataOutputStream(conn.getOutputStream());
+                String parameters = getPostDataString(this.postDataParams);
+                Log.i("HTTP.parameters", parameters);
+                request.writeBytes(parameters);
+                request.flush();
+                request.close();
             }
 
-            Log.i("HTTP.request", request.getMethod() + " " + request.getURI());
+            Log.i("HTTP.request", conn.getRequestMethod() + " " + conn.getURL());
 
-            String authstr = this.app.getEmail() + ":" + this.app.getApiKey();
-            request.setHeader(
-                    "Authorization",
-                    "Basic "
-                            + Base64.encodeToString(authstr.getBytes(),
-                                    Base64.NO_WRAP));
             // timeout after 60 seconds in ms
-            HttpConnectionParams.setSoTimeout(request.getParams(), 60 * 1000);
+            conn.setConnectTimeout(60 * 1000);
+            conn.connect();
 
-            response = httpclient.execute(request);
+            InputStream responseStream;
 
-            StatusLine statusLine = response.getStatusLine();
+            if(conn.getResponseCode() >= HttpStatus.SC_BAD_REQUEST)
+                responseStream = conn.getErrorStream();
+            else
+                responseStream = conn.getInputStream();
 
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            response.getEntity().writeTo(out);
-            out.close();
-            responseString = out.toString();
-            if (statusLine.getStatusCode() != HttpStatus.SC_OK) {
-                Log.e("HTTP", statusLine.getReasonPhrase());
+            responseStream = new BufferedInputStream(responseStream);
+            BufferedReader responseStreamReader = new BufferedReader(new InputStreamReader(responseStream));
+
+            String line;
+            StringBuilder stringBuilder = new StringBuilder();
+
+            while ((line = responseStreamReader.readLine()) != null) {
+                stringBuilder.append(line).append('\n');
+            }
+
+            responseStreamReader.close();
+            responseString = stringBuilder.toString();
+            responseStream.close();
+
+            if (conn.getResponseCode() != HttpStatus.SC_OK) {
+                Log.e("HTTP", conn.getResponseMessage());
                 Log.e("HTTP", responseString);
-                throw new HttpResponseException(statusLine.getStatusCode(),
-                        responseString);
+                throw new HttpResponseException(conn.getResponseCode(), responseString);
             }
         } finally {
-            httpclient.close();
+            conn.disconnect();
         }
 
-        if (responseString != null) {
-            Log.i("HTTP.response", responseString);
-        } else {
-            Log.i("HTTP.response", "<empty>");
-        }
+        Log.i("HTTP.response", responseString);
         return responseString;
     }
 }


### PR DESCRIPTION
As I detailed in #1 I rewrote the `HTTPRequest` class using the native `java.net.HttpsURLConnection` because the Apache Http lib doesn't support [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) and because starting from Android 5.1 all the `org.apache.http` classes are being [deprecated](https://developer.android.com/about/versions/android-5.1.html#http).

Not supporting SNI means that when your Zulip instance is hosted on a virtualhost the TLS auth fails even if the certificate is valid and trusted.