### PR TITLE
Fix #15: integration bots profile images fetch

### DIFF
--- a/src/com/zulip/android/GravatarAsyncFetchTask.java
+++ b/src/com/zulip/android/GravatarAsyncFetchTask.java
@@ -1,7 +1,10 @@
 package com.zulip.android;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -62,13 +65,10 @@ class GravatarAsyncFetchTask extends AsyncTask<URL, Void, Bitmap> {
 
     static Bitmap fetch(URL url) throws IOException {
         Log.i("GAFT.fetch", "Getting gravatar from url: " + url);
-        URLConnection connection = url.openConnection();
-        connection.setUseCaches(true);
-        Object response = connection.getContent();
-        if (response instanceof InputStream) {
-            return BitmapFactory.decodeStream((InputStream) response);
-        }
-        return null;
+        URLConnection conn = url.openConnection();
+        conn.setUseCaches(true);
+        conn.connect();
+        return BitmapFactory.decodeStream(new BufferedInputStream(conn.getInputStream()));
     }
 
     // Once complete, see if ImageView is still around and set bitmap.

--- a/src/com/zulip/android/MessageAdapter.java
+++ b/src/com/zulip/android/MessageAdapter.java
@@ -144,9 +144,14 @@ public class MessageAdapter extends ArrayAdapter<Message> {
             // Gravatar already exists for this image, set the ImageView to it
             gravatar.setImageBitmap(gravatar_img);
         } else {
+            // Check if the profile is an integration bot: if it is the case then its url will be
+            // only a path relative to the Zulip deploy root. So we must add the base url.
+            String avatarURL = message.getSender().getAvatarURL();
+            if (avatarURL.contains("/user_avatars")) {
+                avatarURL = context.app.getServerURI().replace("/api", "") + avatarURL;
+            }
             // Go get the Bitmap
-            URL url = GravatarAsyncFetchTask.sizedURL(context, message
-                    .getSender().getAvatarURL(), 35);
+            URL url = GravatarAsyncFetchTask.sizedURL(context, avatarURL, 35);
             GravatarAsyncFetchTask task = new GravatarAsyncFetchTask(context,
                     gravatar, message.getSender());
             task.loadBitmap(context, url, gravatar, message.getSender());


### PR DESCRIPTION
Bot integrations profile images paths are relative to the server root, with a path like `/user_avatars/<BOT_IMAGE_ID>` instead of `https://secure.gravatar.com/users/<USERHASH>` which is typical for real users.

The app tried to fetch them without checks, failing for them not being correct absolute URLs.