### PR TITLE
Add an server option to the login screen

### DIFF
--- a/res/layout/login.xml
+++ b/res/layout/login.xml
@@ -38,13 +38,23 @@
         android:hint="@string/password"
         android:inputType="textPassword" />
 
+    <EditText
+        android:id="@+id/server_url"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:layout_below="@+id/password"
+        android:ems="10"
+        android:hint="@string/server_url"
+        android:inputType="textUri" />
+
     <Button
         android:id="@+id/login"
         style="android:buttonStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
-        android:layout_below="@+id/password"
+        android:layout_below="@+id/server_url"
         android:layout_marginTop="20dp"
         android:text="@string/login_button" />
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="login_button">Log in</string>
     <string name="username">Email</string>
     <string name="password">Password</string>
+    <string name="server_url">api.zulip.com</string>
     <string name="legal">Legal information</string>
     <string name="logout">Log out</string>
     <string name="compose_stream">Compose message to Stream</string>

--- a/src/com/zulip/android/LoginActivity.java
+++ b/src/com/zulip/android/LoginActivity.java
@@ -37,6 +37,25 @@ public class LoginActivity extends Activity implements View.OnClickListener,
     private ProgressDialog connectionProgressDialog;
     private int googleFailureCount = 0;
 
+    private void saveServerURL() {
+        String serverURL = ((EditText) findViewById(R.id.server_url))
+                                .getText().toString();
+
+        if (!serverURL.startsWith("https://")) {
+            serverURL = "https://" + serverURL;
+        }
+
+        if (!serverURL.endsWith("/")) {
+            serverURL = serverURL + "/";
+        }
+
+        if (!serverURL.startsWith("https://api.zulip.com/")) {
+            serverURL = serverURL + "api/";
+        }
+
+        app.setServerURL(serverURL);
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -49,6 +68,7 @@ public class LoginActivity extends Activity implements View.OnClickListener,
                     @Override
                     public void onClick(View v) {
                         connectionProgressDialog.show();
+                        saveServerURL();
                         AsyncLogin alog = new AsyncLogin(that,
                                 ((EditText) findViewById(R.id.username))
                                         .getText().toString(),

--- a/src/com/zulip/android/ZulipApp.java
+++ b/src/com/zulip/android/ZulipApp.java
@@ -127,7 +127,10 @@ public class ZulipApp extends Application {
         if (getEmail().equals("iago@zulip.com")) {
             return "http://10.0.2.2:9991/api/";
         }
-        return "https://api.zulip.com/";
+        return settings.getString(
+            "server_url",
+            "https://api.zulip.com/"
+        );
     }
 
     public String getApiKey() {
@@ -151,6 +154,12 @@ public class ZulipApp extends Application {
         this.you = Person.getOrUpdate(this, email, null, null);
     }
 
+    public void setServerURL(String serverURL) {
+        Editor ed = this.settings.edit();
+        ed.putString("server_url", serverURL);
+        ed.commit();
+    }
+
     public void setLoggedInApiKey(String apiKey) {
         this.api_key = apiKey;
         Editor ed = this.settings.edit();
@@ -164,6 +173,7 @@ public class ZulipApp extends Application {
         Editor ed = this.settings.edit();
         ed.remove("email");
         ed.remove("api_key");
+        ed.remove("server_url");
         ed.commit();
         this.api_key = null;
         setEventQueueId(null);


### PR DESCRIPTION
Allow users to set a custom zulip server. We special case the URL format
of api.zulip.com to not include /api/.