### PR TITLE
Update ZulipActivity.java

### DIFF
--- a/src/com/zulip/android/ZulipActivity.java
+++ b/src/com/zulip/android/ZulipActivity.java
@@ -448,33 +448,33 @@ public class ZulipActivity extends FragmentActivity implements
         if (this.logged_in) {
             MenuInflater inflater = getMenuInflater();
             inflater.inflate(R.menu.options, menu);
-        }
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            // Get the SearchView and set the searchable configuration
-            SearchManager searchManager = (SearchManager) getSystemService(Context.SEARCH_SERVICE);
-            final MenuItem searchMenuItem = menu.findItem(R.id.search);
-            SearchView searchView = (SearchView) searchMenuItem.getActionView();
-            // Assumes current activity is the searchable activity
-            searchView.setSearchableInfo(searchManager
-                    .getSearchableInfo(getComponentName()));
-
-            searchView
-                    .setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-                        @Override
-                        public boolean onQueryTextSubmit(String s) {
-                            doNarrow(new NarrowFilterSearch(s));
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-                                searchMenuItem.collapseActionView();
-                            }
-                            return true;
-                        }
-
-                        @Override
-                        public boolean onQueryTextChange(String s) {
-                            return false;
-                        }
-                    });
+            
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                    // Get the SearchView and set the searchable configuration
+                    SearchManager searchManager = (SearchManager) getSystemService(Context.SEARCH_SERVICE);
+                    final MenuItem searchMenuItem = menu.findItem(R.id.search);
+                    SearchView searchView = (SearchView) searchMenuItem.getActionView();
+                    // Assumes current activity is the searchable activity
+                    searchView.setSearchableInfo(searchManager
+                            .getSearchableInfo(getComponentName()));
+        
+                    searchView
+                            .setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+                                @Override
+                                public boolean onQueryTextSubmit(String s) {
+                                    doNarrow(new NarrowFilterSearch(s));
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+                                        searchMenuItem.collapseActionView();
+                                    }
+                                    return true;
+                                }
+        
+                                @Override
+                                public boolean onQueryTextChange(String s) {
+                                    return false;
+                                }
+                            });
+            }
         }
         return true;
     }
@@ -496,7 +496,7 @@ public class ZulipActivity extends FragmentActivity implements
                     FragmentManager.POP_BACK_STACK_INCLUSIVE);
             break;
         case R.id.search:
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
                 AlertDialog.Builder builder = new AlertDialog.Builder(this);
                 builder.setTitle("Search Zulip");
                 final EditText editText = new EditText(this);


### PR DESCRIPTION
When checking ```Build.VERSION.SDK_INT``` it should be 'higher or equal'. Also the search related functions should be inside the ```logged_in``` section, not outside it, or  it will receive a null pointer if not logged in / no view related to the search  section.

Related and fix to issue https://github.com/zulip/zulip-android/issues/6