### PR TITLE
Spiffify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,4 @@ res/values/com_crashlytics_export_strings.xml
 /build/
 .gradle/
 *.iml
-.idea/workspace.xml
-.idea/libraries
+.idea

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,9 @@ android {
         minSdkVersion 13
         targetSdkVersion 23
 
+        versionCode 11
+        versionName "0.8.9"
+
         testApplicationId "com.zulip.android.test"
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,9 +15,14 @@ android {
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
     }
     buildTypes {
+        debug {
+            applicationIdSuffix '.dev'
+            manifestPlaceholders = [ permissionPackage : "com.humbughq.mobile.dev"]
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            manifestPlaceholders = [ permissionPackage : "com.humbughq.mobile"]
         }
     }
     useLibrary  'org.apache.http.legacy'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,10 +9,10 @@
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
     <permission
-        android:name="com.humbughq.mobile.permission.C2D_MESSAGE"
+        android:name="${permissionPackage}.permission.C2D_MESSAGE"
         android:protectionLevel="signature" />
 
-    <uses-permission android:name="com.humbughq.mobile.permission.C2D_MESSAGE" />
+    <uses-permission android:name="${permissionPackage}.permission.C2D_MESSAGE" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.zulip.android"
-    android:versionCode="11"
-    android:versionName="0.8.9" >
+    >
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />

--- a/app/src/main/java/com/zulip/android/BuildHelper.java
+++ b/app/src/main/java/com/zulip/android/BuildHelper.java
@@ -1,0 +1,14 @@
+package com.zulip.android;
+
+import android.os.Build;
+
+public class BuildHelper {
+
+    public static boolean shouldLogToCrashlytics() {
+        return !isEmulator() && !BuildConfig.DEBUG;
+    }
+
+    public static boolean isEmulator() {
+        return Build.HARDWARE.contains("goldfish");
+    }
+}

--- a/app/src/main/java/com/zulip/android/ZLog.java
+++ b/app/src/main/java/com/zulip/android/ZLog.java
@@ -1,13 +1,11 @@
 package com.zulip.android;
 
-import android.os.Build;
-
 import com.crashlytics.android.Crashlytics;
 
 public class ZLog {
 
     public static void logException(Throwable e) {
-        if (Build.HARDWARE.contains("goldfish")) {
+        if (BuildHelper.shouldLogToCrashlytics()) {
             e.printStackTrace();
         } else {
             Crashlytics.logException(e);

--- a/app/src/main/java/com/zulip/android/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/ZulipActivity.java
@@ -1,10 +1,7 @@
 package com.zulip.android;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -47,7 +44,6 @@ import android.widget.ListView;
 import android.widget.SearchView;
 import android.widget.TextView;
 
-import com.crashlytics.android.Crashlytics;
 import com.j256.ormlite.android.AndroidDatabaseResults;
 
 public class ZulipActivity extends FragmentActivity implements
@@ -155,12 +151,6 @@ public class ZulipActivity extends FragmentActivity implements
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        if (Build.HARDWARE.contains("goldfish")) {
-            Log.i("hardware", "running in emulator");
-        } else {
-            Crashlytics.start(this);
-        }
 
         app = (ZulipApp) getApplicationContext();
         settings = app.settings;

--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -10,7 +10,6 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
-import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
 
@@ -72,10 +71,7 @@ public class ZulipApp extends Application {
         lastEventId = settings.getInt("lastEventId", -1);
         pointer = settings.getInt("pointer", -1);
 
-
-        if (Build.HARDWARE.contains("goldfish") || BuildConfig.DEBUG) { // dont load crashlytics for debug builds
-            Log.i("hardware", "running in emulator");
-        } else {
+        if (BuildHelper.shouldLogToCrashlytics()) {
             Crashlytics.start(this);
         }
 

--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -10,9 +10,11 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
 
+import com.crashlytics.android.Crashlytics;
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.dao.RuntimeExceptionDao;
 
@@ -69,6 +71,13 @@ public class ZulipApp extends Application {
         eventQueueId = settings.getString("eventQueueId", null);
         lastEventId = settings.getInt("lastEventId", -1);
         pointer = settings.getInt("pointer", -1);
+
+
+        if (Build.HARDWARE.contains("goldfish") || BuildConfig.DEBUG) { // dont load crashlytics for debug builds
+            Log.i("hardware", "running in emulator");
+        } else {
+            Crashlytics.start(this);
+        }
 
         this.api_key = settings.getString("api_key", null);
 


### PR DESCRIPTION
This PR cleans up the app start up a bit, making it possible to install 2 versions of Zulip on a single phone (dev & the prod version).  We avoid Crashlytics for debug builds (to help keep the crash logs clean).

One caveat: having duplicate copies for zulip required changing the CD2_MESSAGE permission namespace for the dev version of the app.  I haven't been able to test it, but this most likely breaks push notifications until a secondary permission/namespace can be added to GCM.