### PR TITLE
squid:S1319 - Declarations should use Java collection interfaces such as 'List' rather than specific implementation classes such as 'LinkedList'

### DIFF
--- a/app/src/main/java/com/zulip/android/AsyncGetOldMessages.java
+++ b/app/src/main/java/com/zulip/android/AsyncGetOldMessages.java
@@ -19,7 +19,7 @@ import com.zulip.android.MessageListener.LoadPosition;
 
 public class AsyncGetOldMessages extends ZulipAsyncPushTask {
     MessageListener listener;
-    public ArrayList<Message> receivedMessages;
+    public List<Message> receivedMessages;
     MessageListener.LoadPosition position;
     protected MessageRange rng;
     protected int mainAnchor;

--- a/app/src/main/java/com/zulip/android/AsyncStatusUpdate.java
+++ b/app/src/main/java/com/zulip/android/AsyncStatusUpdate.java
@@ -1,17 +1,14 @@
 package com.zulip.android;
 
 import android.content.Context;
-import android.os.*;
-import android.os.Message;
 import android.util.Log;
 import android.widget.Toast;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.Iterator;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 
 /**
  * Sends a status update and fetches updates for other users.
@@ -94,7 +91,7 @@ public class AsyncStatusUpdate extends ZulipAsyncPushTask {
 
                 if (obj.getString("result").equals("success")) {
 
-                    ConcurrentHashMap<String, Presence> presenceLookup = this.app.presences;
+                    Map<String, Presence> presenceLookup = this.app.presences;
                     presenceLookup.clear();
 
                     JSONObject presences = obj.getJSONObject("presences");

--- a/app/src/main/java/com/zulip/android/Message.java
+++ b/app/src/main/java/com/zulip/android/Message.java
@@ -4,8 +4,8 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -84,8 +84,8 @@ public class Message {
      * @throws JSONException
      */
     public Message(ZulipApp app, JSONObject message,
-                   HashMap<String, Person> personCache,
-                   HashMap<String, Stream> streamCache) throws JSONException {
+                   Map<String, Person> personCache,
+                   Map<String, Stream> streamCache) throws JSONException {
         this.setID(message.getInt("id"));
         this.setSender(Person.getOrUpdate(app,
                 message.getString("sender_email"),

--- a/app/src/main/java/com/zulip/android/Person.java
+++ b/app/src/main/java/com/zulip/android/Person.java
@@ -1,7 +1,5 @@
 package com.zulip.android;
 
-import android.database.Cursor;
-
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Comparator;
@@ -13,7 +11,6 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.j256.ormlite.android.AndroidDatabaseResults;
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.dao.RuntimeExceptionDao;
 import com.j256.ormlite.field.DatabaseField;
@@ -137,7 +134,7 @@ public class Person {
     }
 
     public static Person getOrUpdate(ZulipApp app, String email, String name,
-                                     String avatarURL, HashMap<String, Person> personCache) {
+                                     String avatarURL, Map<String, Person> personCache) {
 
         Person person = null;
 

--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -1,6 +1,8 @@
 package com.zulip.android;
 
 import java.sql.SQLException;
+import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -43,13 +45,13 @@ public class ZulipApp extends Application {
      * Mapping of email address to presence information for that user. This is
      * updated every 2 minutes by a background thread (see AsyncStatusUpdate)
      */
-    public final ConcurrentHashMap<String, Presence> presences = new ConcurrentHashMap<String, Presence>();
+    public final Map<String, Presence> presences = new ConcurrentHashMap<String, Presence>();
 
     /**
      * Queue of message ids to be marked as read. This queue should be emptied
      * every couple of seconds
      */
-    public final ConcurrentLinkedQueue<Integer> unreadMessageQueue = new ConcurrentLinkedQueue<Integer>();
+    public final Queue<Integer> unreadMessageQueue = new ConcurrentLinkedQueue<Integer>();
 
     public static ZulipApp get() {
         return instance;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
George Kankava