### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/app/src/main/java/com/zulip/android/ComposeDialog.java
+++ b/app/src/main/java/com/zulip/android/ComposeDialog.java
@@ -37,6 +37,9 @@ public class ComposeDialog extends DialogFragment {
     private EditText body;
     private View view;
 
+    public ComposeDialog() {
+    }
+
     public static ComposeDialog newInstance(MessageType type, String stream,
                                             String topic, String pmRecipients) {
         ComposeDialog d = new ComposeDialog();
@@ -50,9 +53,6 @@ public class ComposeDialog extends DialogFragment {
         args.putString("pmRecipients", pmRecipients);
         d.setArguments(args);
         return d;
-    }
-
-    public ComposeDialog() {
     }
 
     /**

--- a/app/src/main/java/com/zulip/android/CustomHtmlToSpannedConverter.java
+++ b/app/src/main/java/com/zulip/android/CustomHtmlToSpannedConverter.java
@@ -63,6 +63,7 @@ class CustomHtmlToSpannedConverter implements ContentHandler {
     private static final float[] HEADER_SIZES = {1.5f, 1.4f, 1.3f, 1.2f, 1.1f,
             1f,};
 
+    private static HashMap<String, Integer> COLORS = buildColorMap();
     private String mSource;
     private XMLReader mReader;
     private SpannableStringBuilder mSpannableStringBuilder;
@@ -607,8 +608,6 @@ class CustomHtmlToSpannedConverter implements ContentHandler {
             mLevel = level;
         }
     }
-
-    private static HashMap<String, Integer> COLORS = buildColorMap();
 
     private static HashMap<String, Integer> buildColorMap() {
         HashMap<String, Integer> map = new HashMap<String, Integer>();

--- a/app/src/main/java/com/zulip/android/Message.java
+++ b/app/src/main/java/com/zulip/android/Message.java
@@ -67,15 +67,6 @@ public class Message {
     public Message(ZulipApp app) {
     }
 
-    static String recipientList(Person[] recipients) {
-        Integer[] ids = new Integer[recipients.length];
-        for (int i = 0; i < recipients.length; i++) {
-            ids[i] = recipients[i].id;
-        }
-        Arrays.sort(ids);
-        return TextUtils.join(",", ids);
-    }
-
     /**
      * Populate a Message object based off a parsed JSON hash.
      *
@@ -144,6 +135,15 @@ public class Message {
 
     public Message(ZulipApp app, JSONObject message) throws JSONException {
         this(app, message, null, null);
+    }
+
+    static String recipientList(Person[] recipients) {
+        Integer[] ids = new Integer[recipients.length];
+        for (int i = 0; i < recipients.length; i++) {
+            ids[i] = recipients[i].id;
+        }
+        Arrays.sort(ids);
+        return TextUtils.join(",", ids);
     }
 
     public int hashCode() {

--- a/app/src/main/java/com/zulip/android/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/MessageListFragment.java
@@ -83,6 +83,12 @@ public class MessageListFragment extends Fragment implements MessageListener {
 
     boolean paused = false;
     boolean initialized = false;
+    List<Message> messageList;
+
+    public MessageListFragment() {
+        app = ZulipApp.get();
+        // Required empty public constructor
+    }
 
     public static MessageListFragment newInstance(NarrowFilter filter) {
         MessageListFragment fragment = new MessageListFragment();
@@ -92,11 +98,6 @@ public class MessageListFragment extends Fragment implements MessageListener {
         return fragment;
     }
 
-    public MessageListFragment() {
-        app = ZulipApp.get();
-        // Required empty public constructor
-    }
-    List<Message> messageList;
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/zulip/android/NarrowFilterAllPMs.java
+++ b/app/src/main/java/com/zulip/android/NarrowFilterAllPMs.java
@@ -20,6 +20,17 @@ public class NarrowFilterAllPMs implements NarrowFilter {
     final Person person;
     final String recipient;
 
+    public static final Parcelable.Creator<NarrowFilterAllPMs> CREATOR = new Parcelable.Creator<NarrowFilterAllPMs>() {
+        public NarrowFilterAllPMs createFromParcel(Parcel in) {
+
+            return new NarrowFilterAllPMs(in.readString());
+        }
+
+        public NarrowFilterAllPMs[] newArray(int size) {
+            return new NarrowFilterAllPMs[size];
+        }
+    };
+
     NarrowFilterAllPMs(Person person) {
         this.person = person;
         this.recipient = Message.recipientList(new Person[]{person});
@@ -38,17 +49,6 @@ public class NarrowFilterAllPMs implements NarrowFilter {
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(recipient);
     }
-
-    public static final Parcelable.Creator<NarrowFilterAllPMs> CREATOR = new Parcelable.Creator<NarrowFilterAllPMs>() {
-        public NarrowFilterAllPMs createFromParcel(Parcel in) {
-
-            return new NarrowFilterAllPMs(in.readString());
-        }
-
-        public NarrowFilterAllPMs[] newArray(int size) {
-            return new NarrowFilterAllPMs[size];
-        }
-    };
 
     @Override
     public Where<Message, Object> modWhere(Where<Message, Object> where)

--- a/app/src/main/java/com/zulip/android/NarrowFilterPM.java
+++ b/app/src/main/java/com/zulip/android/NarrowFilterPM.java
@@ -19,6 +19,16 @@ public class NarrowFilterPM implements NarrowFilter {
     List<Person> people;
     String recipientString;
 
+    public static final Parcelable.Creator<NarrowFilterPM> CREATOR = new Parcelable.Creator<NarrowFilterPM>() {
+        public NarrowFilterPM createFromParcel(Parcel in) {
+            return new NarrowFilterPM(in.readString());
+        }
+
+        public NarrowFilterPM[] newArray(int size) {
+            return new NarrowFilterPM[size];
+        }
+    };
+
     NarrowFilterPM(List<Person> people) {
         this.people = people;
         this.recipientString = Message.recipientList(people
@@ -41,16 +51,6 @@ public class NarrowFilterPM implements NarrowFilter {
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(this.recipientString);
     }
-
-    public static final Parcelable.Creator<NarrowFilterPM> CREATOR = new Parcelable.Creator<NarrowFilterPM>() {
-        public NarrowFilterPM createFromParcel(Parcel in) {
-            return new NarrowFilterPM(in.readString());
-        }
-
-        public NarrowFilterPM[] newArray(int size) {
-            return new NarrowFilterPM[size];
-        }
-    };
 
     @Override
     public Where<Message, Object> modWhere(Where<Message, Object> where)

--- a/app/src/main/java/com/zulip/android/NarrowFilterSearch.java
+++ b/app/src/main/java/com/zulip/android/NarrowFilterSearch.java
@@ -18,6 +18,18 @@ import java.util.Arrays;
 public class NarrowFilterSearch implements NarrowFilter {
     private final String query;
 
+    public static final Creator<NarrowFilterSearch> CREATOR = new Creator<NarrowFilterSearch>() {
+        @Override
+        public NarrowFilterSearch createFromParcel(Parcel parcel) {
+            return new NarrowFilterSearch(parcel.readString());
+        }
+
+        @Override
+        public NarrowFilterSearch[] newArray(int i) {
+            return new NarrowFilterSearch[i];
+        }
+    };
+
     public NarrowFilterSearch(String query) {
         this.query = query;
     }
@@ -63,18 +75,6 @@ public class NarrowFilterSearch implements NarrowFilter {
         filter.put(new JSONArray(Arrays.asList("search", query)));
         return filter.toString();
     }
-
-    public static final Creator<NarrowFilterSearch> CREATOR = new Creator<NarrowFilterSearch>() {
-        @Override
-        public NarrowFilterSearch createFromParcel(Parcel parcel) {
-            return new NarrowFilterSearch(parcel.readString());
-        }
-
-        @Override
-        public NarrowFilterSearch[] newArray(int i) {
-            return new NarrowFilterSearch[i];
-        }
-    };
 
     @Override
     public int describeContents() {

--- a/app/src/main/java/com/zulip/android/NarrowFilterStream.java
+++ b/app/src/main/java/com/zulip/android/NarrowFilterStream.java
@@ -16,6 +16,18 @@ public class NarrowFilterStream implements NarrowFilter {
     Stream stream;
     String subject;
 
+    public static final Parcelable.Creator<NarrowFilterStream> CREATOR = new Parcelable.Creator<NarrowFilterStream>() {
+        public NarrowFilterStream createFromParcel(Parcel in) {
+            String[] pair = in.createStringArray();
+            return new NarrowFilterStream(Stream.getByName(ZulipApp.get(),
+                    pair[0]), pair[1]);
+        }
+
+        public NarrowFilterStream[] newArray(int size) {
+            return new NarrowFilterStream[size];
+        }
+    };
+
     public NarrowFilterStream(Stream stream, String subject) {
         this.stream = stream;
         this.subject = subject;
@@ -29,18 +41,6 @@ public class NarrowFilterStream implements NarrowFilter {
         String[] pair = {stream.getName(), subject};
         dest.writeStringArray(pair);
     }
-
-    public static final Parcelable.Creator<NarrowFilterStream> CREATOR = new Parcelable.Creator<NarrowFilterStream>() {
-        public NarrowFilterStream createFromParcel(Parcel in) {
-            String[] pair = in.createStringArray();
-            return new NarrowFilterStream(Stream.getByName(ZulipApp.get(),
-                    pair[0]), pair[1]);
-        }
-
-        public NarrowFilterStream[] newArray(int size) {
-            return new NarrowFilterStream[size];
-        }
-    };
 
     @Override
     public Where<Message, Object> modWhere(Where<Message, Object> where)

--- a/app/src/main/java/com/zulip/android/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/ZulipActivity.java
@@ -56,29 +56,6 @@ public class ZulipActivity extends FragmentActivity implements
 
     ZulipApp app;
     List<Message> mutedTopics;
-    @Override
-    public void addToList(Message message) {
-        mutedTopics.add(message);
-    }
-
-    @Override
-    public void muteTopic(Message message) {
-        app.muteTopic(message);
-        for (int i = homeList.adapter.getCount() - 1; i >= 0; i--) {
-            if (homeList.adapter.getItem(i).getStream() != null) {
-                if (homeList.adapter.getItem(i).getStream().getId() == message.getStream().getId() && homeList.adapter.getItem(i).getSubject().equals(message.getSubject())) {
-                    mutedTopics.add(homeList.adapter.getItem(i));
-                    homeList.adapter.remove(homeList.adapter.getItem(i));
-                }
-            }
-        }
-        homeList.adapter.notifyDataSetChanged();
-    }
-
-    // Intent Extra constants
-    public enum Flag {
-        RESET_DATABASE,
-    }
 
     boolean suspended = false;
     boolean logged_in = false;
@@ -103,6 +80,21 @@ public class ZulipActivity extends FragmentActivity implements
     MessageListFragment homeList;
 
     Notifications notifications;
+
+    private BroadcastReceiver onGcmMessage = new BroadcastReceiver() {
+        public void onReceive(Context contenxt, Intent intent) {
+            // Block the event before it propagates to show a notification.
+            // TODO: could be smarter and only block the event if the message is
+            // in the narrow.
+            Log.i("GCM", "Dropping a push because the activity is active");
+            abortBroadcast();
+        }
+    };
+
+    // Intent Extra constants
+    public enum Flag {
+        RESET_DATABASE,
+    }
 
     private SimpleCursorAdapter.ViewBinder streamBinder = new SimpleCursorAdapter.ViewBinder() {
 
@@ -170,6 +162,25 @@ public class ZulipActivity extends FragmentActivity implements
 
     protected RefreshableCursorAdapter streamsAdapter;
     protected RefreshableCursorAdapter peopleAdapter;
+
+    @Override
+    public void addToList(Message message) {
+        mutedTopics.add(message);
+    }
+
+    @Override
+    public void muteTopic(Message message) {
+        app.muteTopic(message);
+        for (int i = homeList.adapter.getCount() - 1; i >= 0; i--) {
+            if (homeList.adapter.getItem(i).getStream() != null) {
+                if (homeList.adapter.getItem(i).getStream().getId() == message.getStream().getId() && homeList.adapter.getItem(i).getSubject().equals(message.getSubject())) {
+                    mutedTopics.add(homeList.adapter.getItem(i));
+                    homeList.adapter.remove(homeList.adapter.getItem(i));
+                }
+            }
+        }
+        homeList.adapter.notifyDataSetChanged();
+    }
 
     /**
      * Called when the activity is first created.
@@ -713,14 +724,4 @@ public class ZulipActivity extends FragmentActivity implements
             narrowedList.onNewMessages(messages);
         }
     }
-
-    private BroadcastReceiver onGcmMessage = new BroadcastReceiver() {
-        public void onReceive(Context contenxt, Intent intent) {
-            // Block the event before it propagates to show a notification.
-            // TODO: could be smarter and only block the event if the message is
-            // in the narrow.
-            Log.i("GCM", "Dropping a push because the activity is active");
-            abortBroadcast();
-        }
-    };
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava