### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/zulip/android/BuildHelper.java
+++ b/app/src/main/java/com/zulip/android/BuildHelper.java
@@ -4,6 +4,8 @@ import android.os.Build;
 
 public class BuildHelper {
 
+    private BuildHelper() {}
+
     public static boolean shouldLogToCrashlytics() {
         return !isEmulator() && !BuildConfig.DEBUG;
     }

--- a/app/src/main/java/com/zulip/android/MD5Util.java
+++ b/app/src/main/java/com/zulip/android/MD5Util.java
@@ -7,6 +7,9 @@ import java.security.*;
  * Gravatar example from http://en.gravatar.com/site/implement/images/java/
  */
 public class MD5Util {
+
+    private MD5Util() {}
+
     public static String hex(byte[] array) {
         StringBuffer sb = new StringBuffer();
         for (int i = 0; i < array.length; ++i) {

--- a/app/src/main/java/com/zulip/android/ZLog.java
+++ b/app/src/main/java/com/zulip/android/ZLog.java
@@ -6,6 +6,8 @@ import com.crashlytics.android.Crashlytics;
 
 public class ZLog {
 
+    private ZLog() {}
+
     public static void logException(Throwable e) {
         if (!BuildHelper.shouldLogToCrashlytics()) {
             Log.e("Error", "oops", e);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava