### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -73,6 +73,8 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
                 GoogleSignInResult result = Auth.GoogleSignInApi.getSignInResultFromIntent(intent);
                 handleSignInResult(result);
                 break;
+            default:
+                break;
         }
     }
 
@@ -257,6 +259,8 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
                 break;
             case R.id.legal_button:
                 openLegal();
+                break;
+            default:
                 break;
         }
     }

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -136,6 +136,8 @@ public class ZulipActivity extends FragmentActivity implements
                     arg0.getBackground().setColorFilter(arg1.getInt(arg2),
                             Mode.MULTIPLY);
                     return true;
+                default:
+                    break;
             }
             return false;
         }
@@ -180,6 +182,8 @@ public class ZulipActivity extends FragmentActivity implements
                         }
                     }
                     return true;
+                default:
+                    break;
             }
             return false;
         }
@@ -442,6 +446,8 @@ public class ZulipActivity extends FragmentActivity implements
                     app.resetDatabase();
                     Log.i(PARAMS, "Database deleted successfully.");
                     this.finish();
+                    break;
+                default:
                     break;
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava