### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -117,7 +117,7 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
 
         // if does not begin with "api.zulip.com" and if the path is empty, use "/api" as first segment in the path
         List<String> paths = serverUri.getPathSegments();
-        if (!serverUri.getHost().startsWith("api.") && paths.size() == 0) {
+        if (!serverUri.getHost().startsWith("api.") && paths.isEmpty()) {
             serverUri = serverUri.buildUpon().appendPath("api").build();
         }
 

--- a/app/src/main/java/com/zulip/android/models/MessageRange.java
+++ b/app/src/main/java/com/zulip/android/models/MessageRange.java
@@ -47,7 +47,7 @@ public class MessageRange extends BaseDaoEnabled<MessageRange, Integer> {
                     .and().ge("high", value).query();
             if (ranges.size() == 1) {
                 return ranges.get(0);
-            } else if (ranges.size() != 0) {
+            } else if (!ranges.isEmpty()) {
                 Log.wtf("rangecheck",
                         "Expected one range, got " + ranges.size()
                                 + " when looking for ID " + value);
@@ -125,7 +125,7 @@ public class MessageRange extends BaseDaoEnabled<MessageRange, Integer> {
                                         where.le("low", high + 1))).query();
 
                         MessageRange rng = new MessageRange(low, high);
-                        if (ranges.size() > 0) {
+                        if (!ranges.isEmpty()) {
                             Log.i("", "our low: " + rng.low + ", our high: "
                                     + rng.high);
                             int db_low = ranges.get(0).low;

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
@@ -270,7 +270,7 @@ public class AsyncGetEvents extends Thread {
             watch.reset();
             watch.start();
 
-            if (messages.size() > 0) {
+            if (!messages.isEmpty()) {
                 Log.i("AsyncGetEvents", "Received " + messages.size()
                         + " messages");
                 Message.createMessages(app, messages);

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetOldMessages.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetOldMessages.java
@@ -121,10 +121,10 @@ public class AsyncGetOldMessages extends ZulipAsyncPushTask {
                     before -= lowerCachedMessages.size();
                     // One more than size to account for missing anchor
                     after -= upperCachedMessages.size() + 1;
-                    if (lowerCachedMessages.size() > 0) {
+                    if (!lowerCachedMessages.isEmpty()) {
                         mainAnchor = lowerCachedMessages.get(0).getID() - 1;
                     }
-                    if (upperCachedMessages.size() > 0) {
+                    if (!upperCachedMessages.isEmpty()) {
                         afterAnchor = upperCachedMessages.get(
                                 upperCachedMessages.size() - 1).getID() + 1;
                     }
@@ -135,8 +135,8 @@ public class AsyncGetOldMessages extends ZulipAsyncPushTask {
                     Log.i("perf",
                             "Retrieving cached messages: " + watch.toString());
 
-                    if (lowerCachedMessages.size() > 0
-                            || upperCachedMessages.size() > 0) {
+                    if (!lowerCachedMessages.isEmpty()
+                            || !upperCachedMessages.isEmpty()) {
                         if (before > 0) {
                             this.recurse(LoadPosition.ABOVE, before, rng,
                                     mainAnchor);
@@ -269,7 +269,7 @@ public class AsyncGetOldMessages extends ZulipAsyncPushTask {
                     noFurtherMessages = true;
                 }
 
-                return receivedMessages.size() > 0;
+                return !receivedMessages.isEmpty();
             } catch (JSONException e) {
                 Log.e("json", "parsing error");
                 ZLog.logException(e);

--- a/app/src/main/java/com/zulip/android/networking/AsyncUnreadMessagesUpdate.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncUnreadMessagesUpdate.java
@@ -24,7 +24,7 @@ public class AsyncUnreadMessagesUpdate extends ZulipAsyncPushTask {
             }
         }
 
-        if (messageIds.size() > 0) {
+        if (!messageIds.isEmpty()) {
             setProperty("messages", "[" + TextUtils.join(",", messageIds) + "]");
             setProperty("flag", "read");
             setProperty("op", "add");


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava