### PR TITLE
Developed Login for DevAuthBackEnd #48

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ android {
 dependencies {
     compile 'com.android.support:support-v13:23.3.0'
     compile 'com.android.support:appcompat-v7:23.3.0'
+    compile "com.android.support:recyclerview-v7:23.0.1"
     compile 'com.google.android.gms:play-services-gcm:8.4.0'
     compile 'com.google.android.gms:play-services-auth:8.4.0'
     compile 'com.j256.ormlite:ormlite-core:4.48'

--- a/app/src/androidTest/java/com/zulip/android/activities/LoginDevAuthTest.java
+++ b/app/src/androidTest/java/com/zulip/android/activities/LoginDevAuthTest.java
@@ -1,0 +1,136 @@
+package com.zulip.android.activities;
+
+
+import android.support.test.espresso.NoMatchingViewException;
+import android.support.test.espresso.ViewAssertion;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.espresso.matcher.BoundedMatcher;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.RecyclerView;
+import android.test.suitebuilder.annotation.LargeTest;
+import android.view.View;
+import android.widget.Button;
+
+import com.zulip.android.R;
+import com.zulip.android.ZulipApp;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.matcher.ViewMatchers.assertThat;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withHint;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withParent;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.AllOf.allOf;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class LoginDevAuthTest {
+
+    @Rule
+    public ActivityTestRule<ZulipActivity> mActivityTestRule = new ActivityTestRule<>(ZulipActivity.class);
+
+    private static String EMAIL_TEST = "";
+    private static String SERVER_URL = "http://10.0.3.2:9991/api/";
+
+    // Convenience helper
+    @Test
+    public void TestSerially() {
+        getDevEmails();
+        loginThroughDevMail();
+    }
+
+    @Before
+    public void setup() {
+        closeSoftKeyboard();
+    }
+
+    public void getDevEmails() {
+
+        closeSoftKeyboard();
+        //Uncheck Checkbox
+        ViewInteraction checkBox = onView(
+                allOf(withId(R.id.checkbox_usezulip), withText("Use Zulip.com"),
+                        withParent(withId(R.id.server)),
+                        isDisplayed()));
+        checkBox.perform(click());
+
+        //Give a Server URL
+        ViewInteraction editText = onView(allOf(withId(R.id.server_url), withHint(R.string.server_domain), withParent(withId(R.id.server)), isDisplayed()));
+        editText.perform(replaceText(SERVER_URL));
+
+        closeSoftKeyboard();
+
+        //Click DevAuth TextView Button
+        ViewInteraction textView = onView(allOf(withId(R.id.local_server_button), withText("Dev Backend testing server"), isDisplayed()));
+        textView.perform(click());
+
+        //Check if there are Emails
+        onView(withId(R.id.devAuthRecyclerView)).check(hasItemsCount());
+    }
+
+    private static boolean matchedBefore = false;
+
+    //This filter returns only one View!
+    private Matcher<View> emailFilter() {
+
+        return new BoundedMatcher<View, Button>(Button.class) {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("ERROR");
+            }
+
+            @Override
+            protected boolean matchesSafely(Button item) {
+                if (!matchedBefore && item.getText().toString().contains("@")) {
+                    EMAIL_TEST = item.getText().toString();
+                    matchedBefore = true;
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+
+
+    public void loginThroughDevMail() {
+
+        //If EMAIL not specified click on first EMAIL.
+        if (EMAIL_TEST.equals("")) {
+            onView(allOf(withId(android.R.id.text1), emailFilter())).perform(click());
+        } else {
+            //Find and click the E-Mail Button.
+            ViewInteraction button = onView(Matchers.allOf(withId(android.R.id.text1), withText(EMAIL_TEST), isDisplayed()));
+            button.perform(click());
+        }
+
+        //Verify Correct E-Mail is Stored
+        assertThat(ZulipApp.get().getEmail(), is(EMAIL_TEST));
+    }
+
+    public static ViewAssertion hasItemsCount() {
+        return new ViewAssertion() {
+            @Override
+            public void check(View view, NoMatchingViewException e) {
+                if (!(view instanceof RecyclerView)) {
+                    throw e;
+                }
+                RecyclerView rv = (RecyclerView) view;
+                assertThat("Items less than 2, which means no E-Mails!", rv.getAdapter().getItemCount(), Matchers.greaterThan(2));
+            }
+        };
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,6 +68,8 @@
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
+
+        <activity android:name=".activities.DevAuthActivity"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -150,9 +150,6 @@ public class ZulipApp extends Application {
      * @return either the production or staging server's URI
      */
     public String getServerURI() {
-        if (getEmail().equals("iago@zulip.com")) {
-            return "http://10.0.2.2:9991/api/";
-        }
         return settings.getString("server_url", DEFAULT_SERVER_URL);
     }
     public String getApiKey() {

--- a/app/src/main/java/com/zulip/android/activities/AuthEmailAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/AuthEmailAdapter.java
@@ -1,0 +1,101 @@
+package com.zulip.android.activities;
+
+import android.content.Context;
+import android.support.annotation.ColorInt;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.zulip.android.R;
+import com.zulip.android.util.AuthClickListener;
+
+import java.util.List;
+
+class AuthEmailAdapter extends RecyclerView.Adapter<AuthEmailAdapter.AuthEmailViewHolder> {
+
+    private static final int VIEW_TYPE_HEADER = 0;
+    private static final int VIEW_TYPE_ADMIN = 1;
+    private static final int VIEW_TYPE_USER = 2;
+    private List<String> emails;
+    private int userStringPosition; //Position of the User String header
+    private static AuthClickListener authClickListener;
+
+    private
+    @ColorInt
+    int devAuthUserColor;
+    private
+    @ColorInt
+    int devAuthAdminColor;
+
+    AuthEmailAdapter(List<String> emails, int directAdminSize, Context context) {
+        this.userStringPosition = directAdminSize + 1; //+1 due to the Administrator String
+        this.emails = emails;
+        devAuthUserColor = ContextCompat.getColor(context, R.color.dev_auth_user);
+        devAuthAdminColor = ContextCompat.getColor(context, R.color.dev_auth_admin);
+    }
+
+    @Override
+    public AuthEmailViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        View v = null;
+        if (viewType == VIEW_TYPE_HEADER)
+            v = LayoutInflater.from(parent.getContext()).inflate(R.layout.dev_auth_header, parent, false);
+        else
+            v = LayoutInflater.from(parent.getContext()).inflate(R.layout.dev_auth_row, parent, false);
+        return new AuthEmailViewHolder(v);
+    }
+
+    @Override
+    public void onBindViewHolder(AuthEmailViewHolder holder, int position) {
+        if (position == 0) {
+            if (userStringPosition == 1)
+                ((TextView) holder.view).setText(R.string.admin_none); //Show none if no admins
+            else ((TextView) holder.view).setText(R.string.admin);
+        } else if (position == userStringPosition)
+            ((TextView) holder.view).setText(R.string.normal_user);
+        else if (position > userStringPosition) {
+            ((Button) holder.view).setText(emails.get(position - 2));
+            holder.view.setBackgroundColor(devAuthUserColor);
+        } else {
+            ((Button) holder.view).setText(emails.get(position - 1));
+            holder.view.setBackgroundColor(devAuthAdminColor);
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return emails.size() + 2;
+        //+2 due to the two headers {"Admin and user"}
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        if (position == 0 || position == userStringPosition) return VIEW_TYPE_HEADER;
+        if (position > userStringPosition) return VIEW_TYPE_USER;
+        else return VIEW_TYPE_ADMIN;
+    }
+
+    void setOnItemClickListener(AuthClickListener authClickListener) {
+        AuthEmailAdapter.authClickListener = authClickListener;
+    }
+
+    class AuthEmailViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+        View view;
+
+        AuthEmailViewHolder(View itemView) {
+            super(itemView);
+            view = itemView.findViewById(android.R.id.text1);
+            if (view instanceof Button) {
+                view.setOnClickListener(this);
+            }
+        }
+
+        @Override
+        public void onClick(View v) {
+            authClickListener.onItemClick(((Button) v).getText().toString());
+        }
+    }
+}

--- a/app/src/main/java/com/zulip/android/activities/DevAuthActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/DevAuthActivity.java
@@ -1,0 +1,53 @@
+package com.zulip.android.activities;
+
+import android.app.Activity;
+import android.app.ProgressDialog;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.zulip.android.R;
+import com.zulip.android.networking.AsyncDevGetEmails;
+import com.zulip.android.networking.AsyncLogin;
+import com.zulip.android.util.ZLog;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DevAuthActivity extends Activity {
+    private ProgressDialog connectionProgressDialog;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_dev_auth);
+        String json = getIntent().getStringExtra(AsyncDevGetEmails.EMAIL_JSON);
+        List<String> emails = new ArrayList<>();
+        int directAdminSize = 1;
+        connectionProgressDialog = new ProgressDialog(this);
+        connectionProgressDialog.setMessage(getString(R.string.signing_in));
+
+        try {
+            JSONObject jsonObject = new JSONObject(json);
+            JSONArray jsonArray = jsonObject.getJSONArray("direct_admins");
+            for (int i = 0; i < jsonArray.length(); i++) {
+                emails.add(jsonArray.get(i).toString());
+            }
+            directAdminSize = jsonArray.length();
+            jsonArray = jsonObject.getJSONArray("direct_users");
+            for (int i = 0; i < jsonArray.length(); i++) {
+                emails.add(jsonArray.get(i).toString());
+            }
+        } catch (JSONException e) {
+            ZLog.logException(e);
+        }
+    }
+
+}

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -22,6 +22,7 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.zulip.android.BuildConfig;
 import com.zulip.android.R;
+import com.zulip.android.networking.AsyncDevGetEmails;
 import com.zulip.android.util.ZLog;
 import com.zulip.android.ZulipApp;
 import com.zulip.android.networking.ZulipAsyncPushTask.AsyncTaskCompleteListener;
@@ -124,7 +125,6 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
         }
 
         ((ZulipApp) getApplication()).setServerURL(serverUri.toString());
-        Toast.makeText(this, getString(R.string.logging_into_server, serverUri.toString()), Toast.LENGTH_SHORT).show();
     }
 
 
@@ -140,7 +140,7 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
                 return;
             }
 
-            final AsyncLogin loginTask = new AsyncLogin(LoginActivity.this, "google-oauth2-token", account.getIdToken());
+            final AsyncLogin loginTask = new AsyncLogin(LoginActivity.this, "google-oauth2-token", account.getIdToken(), false);
             loginTask.setCallback(new AsyncTaskCompleteListener() {
                 @Override
                 public void onTaskComplete(String result, JSONObject object) {
@@ -233,15 +233,17 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
             case R.id.google_sign_in_button:
                 connectionProgressDialog.show();
                 saveServerURL();
+                Toast.makeText(this, getString(R.string.logging_into_server, ZulipApp.get().getServerURI()), Toast.LENGTH_SHORT).show();
                 setupGoogleSignIn();
                 break;
             case R.id.zulip_login:
                 if (!isInputValid()) return;
                 saveServerURL();
+                Toast.makeText(this, getString(R.string.logging_into_server, ZulipApp.get().getServerURI()), Toast.LENGTH_SHORT).show();
                 connectionProgressDialog.show();
 
                 AsyncLogin alog = new AsyncLogin(LoginActivity.this,
-                        mUserName.getText().toString(), mPassword.getText().toString());
+                        mUserName.getText().toString(), mPassword.getText().toString(), false);
                 // Remove the CPD when done
                 alog.setCallback(new AsyncTaskCompleteListener() {
                     @Override
@@ -260,11 +262,35 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
             case R.id.legal_button:
                 openLegal();
                 break;
+            case R.id.local_server_button:
+                if (!isInputValidForDevAuth()) return;
+                saveServerURL();
+                AsyncDevGetEmails asyncDevGetEmails = new AsyncDevGetEmails(LoginActivity.this);
+                asyncDevGetEmails.execute();
             default:
                 break;
         }
     }
+    private boolean isInputValidForDevAuth() {
+        boolean isValid = true;
 
+        if (!mUseZulipCheckbox.isChecked()) {
+            if (mServerEditText.length() == 0) {
+                isValid = false;
+                mServerEditText.setError(getString(R.string.server_domain_required));
+            } else {
+                String serverString = mServerEditText.getText().toString();
+                if (!serverString.contains("://")) serverString = "https://" + serverString;
+
+                if (!Patterns.WEB_URL.matcher(serverString).matches()) {
+                    mServerEditText.setError(getString(R.string.invalid_domain));
+                    isValid = false;
+                }
+            }
+        }
+
+        return isValid;
+    }
     private boolean isInputValid() {
         boolean isValid = true;
 

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -64,6 +64,7 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
         mUseZulipCheckbox.setOnCheckedChangeListener(this);
         mUserName = (EditText) findViewById(R.id.username);
         mPassword = (EditText) findViewById(R.id.password);
+        if (!BuildConfig.DEBUG) findViewById(R.id.local_server_button).setVisibility(View.GONE);
     }
 
     @Override

--- a/app/src/main/java/com/zulip/android/networking/AsyncDevGetEmails.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncDevGetEmails.java
@@ -1,0 +1,71 @@
+package com.zulip.android.networking;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.zulip.android.R;
+import com.zulip.android.ZulipApp;
+import com.zulip.android.activities.DevAuthActivity;
+import com.zulip.android.activities.LoginActivity;
+import com.zulip.android.util.ZLog;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpResponseException;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class AsyncDevGetEmails extends ZulipAsyncPushTask {
+    private static final String DISABLED = "dev_disabled";
+    Context context;
+    public final static String EMAIL_JSON = "emails_json";
+
+    public AsyncDevGetEmails(LoginActivity loginActivity) {
+        super((ZulipApp) loginActivity.getApplication());
+        context = loginActivity;
+    }
+
+    public final void execute() {
+        execute("GET", "v1/dev_get_emails");
+    }
+
+    @Override
+    protected void onPostExecute(String result) {
+        try {
+            JSONObject obj = new JSONObject(result);
+            if (obj.getString("result").equals("success")) {
+                Intent intent = new Intent(context, DevAuthActivity.class);
+                intent.putExtra(EMAIL_JSON, result);
+                context.startActivity(intent);
+            }
+        } catch (JSONException e) {
+            ZLog.logException(e);
+        }
+    }
+
+
+    @Override
+    protected void handleHTTPError(final HttpResponseException e) {
+        if (e.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+            String message = context.getString(R.string.network_error);
+            try {
+                JSONObject obj = new JSONObject(e.getMessage());
+                message = obj.getString("msg");
+            } catch (JSONException e1) {
+                ZLog.logException(e1);
+            }
+            final String finalMessage = message;
+            ((LoginActivity) context).runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    Toast.makeText(context, finalMessage, Toast.LENGTH_LONG)
+                            .show();
+                }
+            });
+        } else {
+            // supermethod invokes cancel for us
+            super.handleHTTPError(e);
+        }
+    }
+}

--- a/app/src/main/java/com/zulip/android/util/AuthClickListener.java
+++ b/app/src/main/java/com/zulip/android/util/AuthClickListener.java
@@ -1,0 +1,5 @@
+package com.zulip.android.util;
+
+public interface AuthClickListener {
+    void onItemClick(String email);
+}

--- a/app/src/main/res/layout/activity_dev_auth.xml
+++ b/app/src/main/res/layout/activity_dev_auth.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="16dp"
+    tools:context="com.zulip.android.activities.DevAuthActivity">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/zulip_dev_login"
+        android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_dev_auth.xml
+++ b/app/src/main/res/layout/activity_dev_auth.xml
@@ -14,4 +14,11 @@
         android:layout_marginTop="8dp"
         android:text="@string/zulip_dev_login"
         android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/devAuthRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:layout_marginTop="16dp" />
 </LinearLayout>

--- a/app/src/main/res/layout/dev_auth_header.xml
+++ b/app/src/main/res/layout/dev_auth_header.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2006 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    android:paddingBottom="8dp"
+    android:paddingTop="8dp"
+
+    android:textAppearance="@style/TextAppearance.AppCompat.Small" />

--- a/app/src/main/res/layout/dev_auth_row.xml
+++ b/app/src/main/res/layout/dev_auth_row.xml
@@ -1,0 +1,16 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center">
+
+    <Button xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@android:id/text1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="10dp"
+        android:gravity="center"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:textColor="@android:color/white" />
+</LinearLayout>

--- a/app/src/main/res/layout/login.xml
+++ b/app/src/main/res/layout/login.xml
@@ -97,6 +97,7 @@
         android:id="@+id/local_server_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:onClick="onClick"
         android:paddingTop="16dp"
         android:text="@string/local_server"
         android:textColor="#ff0099cc" />

--- a/app/src/main/res/layout/login.xml
+++ b/app/src/main/res/layout/login.xml
@@ -94,10 +94,18 @@
     </com.google.android.gms.common.SignInButton>
 
     <TextView
+        android:id="@+id/local_server_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        android:text="@string/local_server"
+        android:textColor="#ff0099cc" />
+
+    <TextView
         android:id="@+id/legal_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:paddingTop="8dp"
         android:text="@string/legal"
-        android:paddingTop="16dp"
         android:textColor="#ff0099cc" />
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="dev_auth_admin">#ff4136</color>
+    <color name="dev_auth_user">#428bca</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="person_error">No Person specified.</string>
     <string name="no_message_error">No Message Written.</string>
     <string name="local_server">Dev Backend testing server</string>
+    <string name="zulip_dev_login">Zulip Dev Login</string>
 
 
     <string name="tap_message">Tap on a message to send reply</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,9 @@
     <string name="no_message_error">No Message Written.</string>
     <string name="local_server">Dev Backend testing server</string>
     <string name="zulip_dev_login">Zulip Dev Login</string>
+    <string name="admin_none">Administrators (None)</string>
+    <string name="admin">Administrators</string>
+    <string name="normal_user">Normal users</string>
 
 
     <string name="tap_message">Tap on a message to send reply</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="subject_error">No Subject specified.</string>
     <string name="person_error">No Person specified.</string>
     <string name="no_message_error">No Message Written.</string>
+    <string name="local_server">Dev Backend testing server</string>
 
 
     <string name="tap_message">Tap on a message to send reply</string>


### PR DESCRIPTION
Now we can directly login using the devAuthBackEnd using a developement server! (#48)


Has a menu same as the Web UI
<img src="https://cloud.githubusercontent.com/assets/12700799/15695247/db98fc6c-27c2-11e6-8abd-cbd01eb2e446.png" width="49%" />


If the devAuthBackEnd is not enabled then it shows a toast error message like this
<img src="https://cloud.githubusercontent.com/assets/12700799/15695248/db9e03ba-27c2-11e6-9e7f-d9fa2f953ecc.png" width="49%" />


[Server code here](https://github.com/zulip/zulip/pull/851)