### PR TITLE
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility

### DIFF
--- a/app/src/androidTest/java/com/zulip/android/test/UnsortedTests.java
+++ b/app/src/androidTest/java/com/zulip/android/test/UnsortedTests.java
@@ -144,7 +144,7 @@ public class UnsortedTests extends ActivityUnitTestCase<ZulipActivity> {
         MessageListFragment fragment = MessageListFragment.newInstance(null);
         fragment.app = app;
         FakeAsyncGetOldMessages request = new FakeAsyncGetOldMessages(fragment);
-        request.shouldFmSucceed = true;
+        request.setShouldFmSucceed(true);
         request.appendTheseMessages = new ArrayList<Message>();
         Message m1 = sampleMessage(app, 40);
         Message m2 = sampleMessage(app, 45);
@@ -164,14 +164,14 @@ public class UnsortedTests extends ActivityUnitTestCase<ZulipActivity> {
         request = new FakeAsyncGetOldMessages(fragment);
         request.execute(45, LoadPosition.INITIAL, 1, 0, null);
         request.get();
-        assertFalse(request.fmCalled);
+        assertFalse(request.isFmCalled());
         assertEquals(2, request.receivedMessages.size());
 
         // Now let's test coalescing...
         // The fetch won't be in cache here, but one message will already be
         // retrieved.
         request = new FakeAsyncGetOldMessages(fragment);
-        request.shouldFmSucceed = true;
+        request.setShouldFmSucceed(true);
         request.appendTheseMessages = new ArrayList<Message>();
         Message m0 = sampleMessage(app, 35);
         request.appendTheseMessages.add(m0);
@@ -187,26 +187,26 @@ public class UnsortedTests extends ActivityUnitTestCase<ZulipActivity> {
         // And test partial hits for good measure!
 
         request = new FakeAsyncGetOldMessages(fragment);
-        request.shouldFmSucceed = true;
+        request.setShouldFmSucceed(true);
         request.execute(36, LoadPosition.INITIAL, 2, 0, null);
         request.get();
 
         // 35 should be in cache
         assertEquals(1, request.receivedMessages.size());
-        assertEquals(false, request.fmCalled);
+        assertEquals(false, request.isFmCalled());
         // Recursing in one direction
         assertEquals(1, request.recurseRequestsReceived.size());
 
         request = request.recurseRequestsReceived.get(0);
-        request.shouldFmSucceed = true;
-        assertEquals(1, request.fmNumBefore);
+        request.setShouldFmSucceed(true);
+        assertEquals(1, request.getFmNumBefore());
         request.appendTheseMessages = new ArrayList<Message>();
         Message mn1 = sampleMessage(app, 33);
         request.appendTheseMessages.add(mn1);
         request.executeBasedOnPresetValues();
         request.get();
 
-        assertEquals(true, request.fmCalled);
+        assertEquals(true, request.isFmCalled());
         assertEquals(1, request.receivedMessages.size());
         mrs = app.getDao(MessageRange.class).queryForAll();
         assertEquals(1, mrs.size());

--- a/app/src/androidTest/java/com/zulip/android/test/mutated/FakeAsyncGetOldMessages.java
+++ b/app/src/androidTest/java/com/zulip/android/test/mutated/FakeAsyncGetOldMessages.java
@@ -11,15 +11,15 @@ import com.zulip.android.networking.AsyncGetOldMessages;
 
 public class FakeAsyncGetOldMessages extends
         AsyncGetOldMessages {
-    public String calculatedResult;
-    public int fmAnchor;
-    public int fmNumBefore;
-    public int fmNumAfter;
-    public boolean shouldFmSucceed;
-    public boolean fmCalled;
+    private String calculatedResult;
+    private int fmAnchor;
+    private int fmNumBefore;
+    private int fmNumAfter;
+    private boolean shouldFmSucceed;
+    private boolean fmCalled;
     public List<Message> appendTheseMessages;
     public List<FakeAsyncGetOldMessages> recurseRequestsReceived;
-    private MessageListFragment myfragment;
+    public MessageListFragment myfragment;
 
     public FakeAsyncGetOldMessages(MessageListFragment fragment) {
         super(fragment);
@@ -69,4 +69,51 @@ public class FakeAsyncGetOldMessages extends
         calculatedResult = result;
     }
 
+    public String getCalculatedResult() {
+        return calculatedResult;
+    }
+
+    public void setCalculatedResult(String calculatedResult) {
+        this.calculatedResult = calculatedResult;
+    }
+
+    public int getFmAnchor() {
+        return fmAnchor;
+    }
+
+    public void setFmAnchor(int fmAnchor) {
+        this.fmAnchor = fmAnchor;
+    }
+
+    public int getFmNumBefore() {
+        return fmNumBefore;
+    }
+
+    public void setFmNumBefore(int fmNumBefore) {
+        this.fmNumBefore = fmNumBefore;
+    }
+
+    public int getFmNumAfter() {
+        return fmNumAfter;
+    }
+
+    public void setFmNumAfter(int fmNumAfter) {
+        this.fmNumAfter = fmNumAfter;
+    }
+
+    public boolean shouldFmSucceed() {
+        return shouldFmSucceed;
+    }
+
+    public void setShouldFmSucceed(boolean shouldFmSucceed) {
+        this.shouldFmSucceed = shouldFmSucceed;
+    }
+
+    public boolean isFmCalled() {
+        return fmCalled;
+    }
+
+    public void setFmCalled(boolean fmCalled) {
+        this.fmCalled = fmCalled;
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
This pull request removes 60 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
Please let me know if you have any questions.
George Kankava