### PR TITLE
Multiple code improvements - squid:S1166, squid:S2696, squid:ModifiersOrderCheck, squid:S3027, squid:S00117, squid:S00122, squid:UselessParenthesesCheck

### DIFF
--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -79,7 +79,7 @@ public class ZulipApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        ZulipApp.instance = this;
+        setInstance(this);
 
         // This used to be from HumbugActivity.getPreferences, so we keep that
         // file name.
@@ -331,5 +331,9 @@ public class ZulipApp extends Application {
 
     public Person getYou() {
         return you;
+    }
+
+    public static void setInstance(ZulipApp instance) {
+        ZulipApp.instance = instance;
     }
 }

--- a/app/src/main/java/com/zulip/android/activities/ComposeDialog.java
+++ b/app/src/main/java/com/zulip/android/activities/ComposeDialog.java
@@ -212,7 +212,7 @@ public class ComposeDialog extends DialogFragment {
                 public CharSequence convertToString(Cursor cursor) {
                     String text = recipient.getText().toString();
                     String prefix;
-                    int lastIndex = text.lastIndexOf(",");
+                    int lastIndex = text.lastIndexOf(',');
                     if (lastIndex != -1) {
                         prefix = text.substring(0, lastIndex + 1);
                     } else {

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 public class LoginActivity extends FragmentActivity implements View.OnClickListener,
         GoogleApiClient.OnConnectionFailedListener, CompoundButton.OnCheckedChangeListener {
+    private static final String TAG = "LoginActivity";
     private static final int REQUEST_CODE_RESOLVE_ERR = 9000;
     private static final int REQUEST_CODE_SIGN_IN = 9001;
 
@@ -191,6 +192,7 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
                 try {
                     result.startResolutionForResult(this, REQUEST_CODE_RESOLVE_ERR);
                 } catch (SendIntentException e) {
+                    Log.e(TAG, e.getMessage(), e);
                     // Yeah, no idea what to do here.
                     connectionProgressDialog.dismiss();
                     Toast.makeText(LoginActivity.this, R.string.google_app_login_failed, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
@@ -48,10 +48,14 @@ public class MessageAdapter extends ArrayAdapter<Message> {
 
     private static final HTMLSchema schema = new HTMLSchema();
 
-    private @ColorInt int mDefaultStreamHeaderColor;
-    private @ColorInt int mDefaultHuddleHeaderColor;
-    private @ColorInt int mDefaultStreamMessageColor;
-    private @ColorInt int mDefaultHuddleMessageColor;
+    @ColorInt
+    private int mDefaultStreamHeaderColor;
+    @ColorInt
+    private int mDefaultHuddleHeaderColor;
+    @ColorInt
+    private int mDefaultStreamMessageColor;
+    @ColorInt
+    private int mDefaultHuddleMessageColor;
 
     public MessageAdapter(Context context, List<Message> objects) {
         super(context, 0, objects);
@@ -77,7 +81,7 @@ public class MessageAdapter extends ArrayAdapter<Message> {
         }
 
         LinearLayout envelopeTile = (LinearLayout) tile.findViewById(R.id.envelopeTile);
-        TextView display_recipient = (TextView) tile.findViewById(R.id.displayRecipient);
+        TextView displayRecipient = (TextView) tile.findViewById(R.id.displayRecipient);
         ImageView muteImageView = (ImageView) tile.findViewById(R.id.muteMessageImage);
 
         if (message.getType() != MessageType.STREAM_MESSAGE) {
@@ -89,21 +93,21 @@ public class MessageAdapter extends ArrayAdapter<Message> {
         }
 
         if (message.getType() != MessageType.STREAM_MESSAGE) {
-            display_recipient.setText(context.getString(R.string.huddle_text, message.getDisplayRecipient(context.app)));
-            display_recipient.setTextColor(Color.WHITE);
-            display_recipient.setOnClickListener(new View.OnClickListener() {
+            displayRecipient.setText(context.getString(R.string.huddle_text, message.getDisplayRecipient(context.app)));
+            displayRecipient.setTextColor(Color.WHITE);
+            displayRecipient.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     if (getContext() instanceof NarrowListener) {
                         ((NarrowListener) getContext()).onNarrow(new NarrowFilterPM(
-                                Arrays.asList(message.getRecipients((ZulipApp.get())))));
+                                Arrays.asList(message.getRecipients(ZulipApp.get()))));
                     }
                 }
             });
         } else {
-            display_recipient.setText(message.getDisplayRecipient(context.app));
-            display_recipient.setTextColor(Color.BLACK);
-            display_recipient.setOnClickListener(new View.OnClickListener() {
+            displayRecipient.setText(message.getDisplayRecipient(context.app));
+            displayRecipient.setTextColor(Color.BLACK);
+            displayRecipient.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     if (getContext() instanceof NarrowListener) {
@@ -112,7 +116,9 @@ public class MessageAdapter extends ArrayAdapter<Message> {
                 }
             });
             if (getContext() instanceof NarrowListener) {
-                if (context.app.isTopicMute(message)) muteImageView.setVisibility(View.VISIBLE);
+                if (context.app.isTopicMute(message)) {
+                    muteImageView.setVisibility(View.VISIBLE);
+                }
                 else muteImageView.setVisibility(View.GONE);
             }
         }
@@ -190,10 +196,10 @@ public class MessageAdapter extends ArrayAdapter<Message> {
         }
 
         ImageView gravatar = (ImageView) tile.findViewById(R.id.gravatar);
-        Bitmap gravatar_img = context.getGravatars().get(message.getSender().getEmail());
-        if (gravatar_img != null) {
+        Bitmap gravatarImg = context.getGravatars().get(message.getSender().getEmail());
+        if (gravatarImg != null) {
             // Gravatar already exists for this image, set the ImageView to it
-            gravatar.setImageBitmap(gravatar_img);
+            gravatar.setImageBitmap(gravatarImg);
         } else {
             // Go get the Bitmap
             URL url = GravatarAsyncFetchTask.sizedURL(context, message.getSender().getAvatarURL(), 35);
@@ -250,7 +256,7 @@ public class MessageAdapter extends ArrayAdapter<Message> {
                                         * scaleFactor * density));
                         return drawable;
                     } catch (IOException e) {
-                        Log.e("MessageAdapter", e.getMessage());
+                        Log.e("MessageAdapter", e.getMessage(), e);
                     }
                 }
                 return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1166 - Exception handlers should preserve the original exception.
squid:S2696 - Instance methods should not write to "static" fields.
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
squid:S3027 - String function use should be optimized for single characters.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S00122 - Statements should be on separate lines.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
This pull request removes 59 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1166
https://dev.eclipse.org/sonar/rules/show/squid:S2696
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
https://dev.eclipse.org/sonar/rules/show/squid:S3027
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava