### PR TITLE
Bugfix api calls and gcm key

### DIFF
--- a/app/src/debug/google-services.json
+++ b/app/src/debug/google-services.json
@@ -29,7 +29,9 @@
           "client_type": 3
         }
       ],
-      "api_key": [],
+      "api_key": [{
+          "current_key": ""
+        }],
       "services": {
         "analytics_service": {
           "status": 1

--- a/app/src/main/java/com/zulip/android/gcm/Notifications.java
+++ b/app/src/main/java/com/zulip/android/gcm/Notifications.java
@@ -118,7 +118,7 @@ public class Notifications {
 
                     HTTPRequest request = new HTTPRequest(app);
                     request.setProperty("token", regid);
-                    request.execute("POST", "v1/users/me/android_gcm_reg_id");
+                    request.execute("POST", "/v1/users/me/android_gcm_reg_id");
 
                     // Persist the regID - no need to register again.
                     storeRegistrationId(app, regid);
@@ -146,7 +146,7 @@ public class Notifications {
 
                     HTTPRequest request = new HTTPRequest(app);
                     request.setProperty("token", regid);
-                    request.execute("DELETE", "v1/users/me/android_gcm_reg_id");
+                    request.execute("DELETE", "/v1/users/me/android_gcm_reg_id");
 
                     storeRegistrationId(app, "");
                     regid = "";

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
@@ -76,15 +76,15 @@ public class AsyncGetEvents extends Thread {
 
         StopWatch watch = new StopWatch();
         watch.start();
-        String responseData = request.execute("POST", "v1/register");
+        String responseData = request.execute("POST", "/v1/register");
         watch.stop();
-        Log.i("perf", "net: v1/register: " + watch.toString());
+        Log.i("perf", "net: /v1/register: " + watch.toString());
 
         watch.reset();
         watch.start();
         JSONObject response = new JSONObject(responseData);
         watch.stop();
-        Log.i("perf", "json: v1/register: " + watch.toString());
+        Log.i("perf", "json: /v1/register: " + watch.toString());
 
         registeredOrGotEventsThisRun = true;
         app.setEventQueueId(response.getString("queue_id"));
@@ -108,7 +108,7 @@ public class AsyncGetEvents extends Thread {
                         request.setProperty("dont_block", "true");
                     }
                     JSONObject response = new JSONObject(request.execute("GET",
-                            "v1/events"));
+                            "/v1/events"));
 
                     JSONArray events = response.getJSONArray("events");
                     if (events.length() > 0) {

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetOldMessages.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetOldMessages.java
@@ -66,7 +66,7 @@ public class AsyncGetOldMessages extends ZulipAsyncPushTask {
         position = pos;
         this.receivedMessages = new ArrayList<Message>();
         Log.i("AGOM", "executing " + anchor + " " + before + " " + after);
-        execute("GET", "v1/messages");
+        execute("GET", "/v1/messages");
     }
 
     @Override
@@ -223,7 +223,7 @@ public class AsyncGetOldMessages extends ZulipAsyncPushTask {
         watch.start();
         String result = super.doInBackground(params);
         watch.stop();
-        Log.i("perf", "net: v1/messages: " + watch.toString());
+        Log.i("perf", "net: /v1/messages: " + watch.toString());
 
         if (result != null) {
             try {
@@ -231,7 +231,7 @@ public class AsyncGetOldMessages extends ZulipAsyncPushTask {
                 watch.start();
                 JSONObject response = new JSONObject(result);
                 watch.stop();
-                Log.i("perf", "json: v1/messages: " + watch.toString());
+                Log.i("perf", "json: /v1/messages: " + watch.toString());
 
                 watch.reset();
                 watch.start();

--- a/app/src/main/java/com/zulip/android/networking/AsyncLogin.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncLogin.java
@@ -32,7 +32,7 @@ public class AsyncLogin extends ZulipAsyncPushTask {
     }
 
     public final void execute() {
-        execute("POST", "v1/fetch_api_key");
+        execute("POST", "/v1/fetch_api_key");
     }
 
     @Override

--- a/app/src/main/java/com/zulip/android/networking/AsyncPointerUpdate.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncPointerUpdate.java
@@ -9,6 +9,6 @@ public class AsyncPointerUpdate extends ZulipAsyncPushTask {
 
     public final void execute(int newPointer) {
         this.setProperty("pointer", Integer.toString(newPointer));
-        execute("PUT", "v1/users/me/pointer");
+        execute("PUT", "/v1/users/me/pointer");
     }
 }

--- a/app/src/main/java/com/zulip/android/networking/AsyncSend.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncSend.java
@@ -34,7 +34,7 @@ public class AsyncSend extends ZulipAsyncPushTask {
     }
 
     public final void execute() {
-        execute("POST", "v1/messages");
+        execute("POST", "/v1/messages");
     }
 
 }

--- a/app/src/main/java/com/zulip/android/networking/AsyncStatusUpdate.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncStatusUpdate.java
@@ -39,7 +39,7 @@ public class AsyncStatusUpdate extends ZulipAsyncPushTask {
     }
 
     public final void execute() {
-        execute("POST", "v1/users/me/presence");
+        execute("POST", "/v1/users/me/presence");
     }
 
     /**

--- a/app/src/main/java/com/zulip/android/networking/AsyncUnreadMessagesUpdate.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncUnreadMessagesUpdate.java
@@ -29,7 +29,7 @@ public class AsyncUnreadMessagesUpdate extends ZulipAsyncPushTask {
             setProperty("flag", "read");
             setProperty("op", "add");
 
-            execute("POST", "v1/messages/flags");
+            execute("POST", "/v1/messages/flags");
         }
     }
 }


### PR DESCRIPTION
Needed to add slashes to all api calls as in "/v1/...". Also fix the problem with the empty current_key value that is now needed with the latest GMS service.