### PR TITLE
Allow non-Zulip.com installs to login via Google Auth

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "23.0.2"
     defaultConfig {
         applicationId "com.zulip.android"
-        minSdkVersion 13
+        minSdkVersion 16
         targetSdkVersion 23
 
         versionCode 11
@@ -70,5 +70,5 @@ dependencies {
     }
     testCompile 'junit:junit:4.12'
     compile 'com.squareup.okhttp3:okhttp:3.3.1'
+    compile 'net.openid:appauth:0.2.0'
 }
-

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,6 @@ dependencies {
     compile 'com.android.support:design:24.0.0'
     compile 'com.android.support:recyclerview-v7:24.0.0'
     compile 'com.google.android.gms:play-services-gcm:8.4.0'
-    compile 'com.google.android.gms:play-services-auth:8.4.0'
     compile 'com.j256.ormlite:ormlite-core:4.48'
     compile 'com.j256.ormlite:ormlite-android:4.48'
     compile 'commons-lang:commons-lang:2.6'
@@ -73,4 +72,3 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.3.1'
 }
 
-apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,18 @@
             android:name=".activities.LoginActivity"
             android:label="@string/app_name"
             android:windowSoftInputMode="stateVisible" >
+            <intent-filter>
+                <action android:name="com.zulip.android.HANDLE_AUTHORIZATION_RESPONSE"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
+        <activity android:name="net.openid.appauth.RedirectUriReceiverActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="com.zulip.android"/>
+            </intent-filter>
         </activity>
         <activity
             android:name=".activities.LegalActivity"

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -8,6 +8,8 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.support.annotation.Nullable;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.util.Patterns;
 import android.view.View;
@@ -162,7 +164,15 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
 
                     @Override
                     public void onTaskFailure(String result) {
-
+                        connectionProgressDialog.dismiss();
+                        if(result.contains("GOOGLE_CLIENT_ID is not configured")){
+                         runOnUiThread(new Runnable() {
+                             @Override
+                             public void run() {
+                                 googleClientNotConfigured();
+                             }
+                         });
+                        }
                     }
                 });
                 asyncFetchGoogleID.execute();
@@ -234,6 +244,29 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
             }
         }
         return isValid;
+    }
+
+    private void googleClientNotConfigured(){
+        Toast.makeText(LoginActivity.this, R.string.google_client_error, Toast.LENGTH_SHORT).show();
+        mGoogleSignInButton.setVisibility(View.GONE);
+        final TextWatcher textWatcher = new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                mGoogleSignInButton.setVisibility(View.VISIBLE);
+                mServerEditText.removeTextChangedListener(this);
+            }
+        };
+        mServerEditText.addTextChangedListener(textWatcher);
     }
 
     private void setupSignIn(String clientId) {

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -286,6 +286,27 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
                             authState.performActionWithFreshTokens(mAuthorizationService, new AuthState.AuthStateAction() {
                                 @Override
                                 public void execute(@Nullable final String accessToken, @Nullable final String idToken, @Nullable AuthorizationException exception) {
+                                    final AsyncLogin loginTask = new AsyncLogin(LoginActivity.this, "google-oauth2-token", idToken, false);
+                                    loginTask.setCallback(new AsyncTaskCompleteListener() {
+                                        @Override
+                                        public void onTaskComplete(String result, JSONObject object) {
+                                            Log.d("RECIEVED", "onTaskComplete: " + result);
+                                            try {
+                                                ((ZulipApp) getApplication()).setEmail(object.getString("email"));
+                                                connectionProgressDialog.dismiss();
+                                            } catch (JSONException e) {
+                                                ZLog.logException(e);
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onTaskFailure(String result) {
+                                            // Invalidate the token and try again, unless the user we
+                                            // are authenticating as is not registered or is disabled.
+                                            connectionProgressDialog.dismiss();
+                                        }
+                                    });
+                                    loginTask.execute();
                                 }
                             });
                             Log.i(GOOGLE_SIGN, String.format("Token Response [ Access Token: %s, ID Token: %s ]", tokenResponse.accessToken, tokenResponse.idToken));

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.support.annotation.Nullable;
 import android.util.Patterns;
 import android.view.View;
 import android.widget.CheckBox;
@@ -41,6 +42,7 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
     private static final String AUTH_CALLBACK = "com.zulip.android:/oauth2callback";
     private static final String AUTH_INTENT_ACTION = "com.zulip.android.HANDLE_AUTHORIZATION_RESPONSE";
 
+    private static final String USED_INTENT = "USED_INTENT";
     private ProgressDialog connectionProgressDialog;
     private EditText mServerEditText;
     private EditText mUserName;
@@ -76,6 +78,7 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
     @Override
     protected void onStart() {
         super.onStart();
+        checkIntent(getIntent());
     }
 
     @Override
@@ -245,6 +248,14 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
         Intent postAuthorizationIntent = new Intent(action);
         PendingIntent pendingIntent = PendingIntent.getActivity(LoginActivity.this, request.hashCode(), postAuthorizationIntent, 0);
         authorizationService.performAuthorizationRequest(request, pendingIntent);
+    }
+
+    private void checkIntent(@Nullable Intent intent) {
+        if (intent != null && intent.getAction() != null) {
+                    if (intent.getAction().equals(AUTH_INTENT_ACTION) && !intent.hasExtra(USED_INTENT)) {
+                        intent.putExtra(USED_INTENT, true);
+            }
+        }
     }
     private boolean isInputValid() {
         boolean isValid = true;

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -20,6 +20,7 @@ import com.zulip.android.BuildConfig;
 import com.zulip.android.R;
 import com.zulip.android.networking.AsyncDevGetEmails;
 import com.zulip.android.util.ZLog;
+import com.zulip.android.networking.AsyncFetchGoogleID;
 import com.zulip.android.ZulipApp;
 import com.zulip.android.networking.ZulipAsyncPushTask.AsyncTaskCompleteListener;
 import com.zulip.android.networking.AsyncLogin;
@@ -129,6 +130,23 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
                 connectionProgressDialog.show();
                 saveServerURL();
                 Toast.makeText(this, getString(R.string.logging_into_server, ZulipApp.get().getServerURI()), Toast.LENGTH_SHORT).show();
+                AsyncFetchGoogleID asyncFetchGoogleID = new AsyncFetchGoogleID(ZulipApp.get());
+                asyncFetchGoogleID.setCallback(new AsyncTaskCompleteListener() {
+                    @Override
+                    public void onTaskComplete(String result, JSONObject jsonObject) {
+                        try {
+                            JSONObject jsonObject1 = new JSONObject(result);
+                        } catch (JSONException e) {
+                            ZLog.logException(e);
+                        }
+                    }
+
+                    @Override
+                    public void onTaskFailure(String result) {
+
+                    }
+                });
+                asyncFetchGoogleID.execute();
                 break;
             case R.id.zulip_login:
                 if (!isInputValid()) {

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -240,7 +240,6 @@ public class LoginActivity extends AppCompatActivity implements View.OnClickList
             mGoogleSignInButton.setVisibility(View.VISIBLE);
         } else {
             mServerEditText.setVisibility(View.VISIBLE);
-            mGoogleSignInButton.setVisibility(View.GONE);
         }
     }
 }

--- a/app/src/main/java/com/zulip/android/networking/AsyncFetchGoogleID.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncFetchGoogleID.java
@@ -1,0 +1,14 @@
+package com.zulip.android.networking;
+
+import com.zulip.android.ZulipApp;
+
+public class AsyncFetchGoogleID extends ZulipAsyncPushTask {
+
+    public AsyncFetchGoogleID(ZulipApp app) {
+        super(app);
+    }
+
+    public final void execute() {
+        execute("GET", "v1/fetch_google_client_id");
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,4 +69,5 @@
     <string name="method_error">Method not supported</string>
     <string name="tap_message">Tap on a message to compose reply</string>
     <string name="title_login">Login</string>
+    <string name="google_client_error">Google client is not configured on this server!</string>
 </resources>


### PR DESCRIPTION
Fixed #64 ! :)
Used [Open-ID Auth](https://github.com/openid/AppAuth-Android) library to create the Auth System!

Requires two Client ID's in the settings.py [here](https://github.com/zulip/zulip/blob/50f723f50bc40433541be662ae3ccc0718d7ed5d/zproject/settings.py#L148)
`'GOOGLE_CLIENT_ID' `and `'GOOGLE_OAUTH2_CLIENT_ID' `and ofcourse `GoogleMobileOauth2Backend` to be enabled in the Authentication Backends! 

Demo:
![google-sigin](https://cloud.githubusercontent.com/assets/12700799/16246103/6a0e1f9a-3821-11e6-8121-2a4b9bd6cc67.gif)
