### PR TITLE
squid:S1166 - Exception handlers should preserve the original exception

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 public class LoginActivity extends FragmentActivity implements View.OnClickListener,
         GoogleApiClient.OnConnectionFailedListener, CompoundButton.OnCheckedChangeListener {
+    private static final String TAG = "LoginActivity";
     private static final int REQUEST_CODE_RESOLVE_ERR = 9000;
     private static final int REQUEST_CODE_SIGN_IN = 9001;
 
@@ -191,6 +192,7 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
                 try {
                     result.startResolutionForResult(this, REQUEST_CODE_RESOLVE_ERR);
                 } catch (SendIntentException e) {
+                    Log.e(TAG, e.getMessage(), e);
                     // Yeah, no idea what to do here.
                     connectionProgressDialog.dismiss();
                     Toast.makeText(LoginActivity.this, R.string.google_app_login_failed, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
@@ -46,6 +46,7 @@ import com.zulip.android.networking.GravatarAsyncFetchTask;
  */
 public class MessageAdapter extends ArrayAdapter<Message> {
 
+    private static final String TAG = "MessageAdapter";
     private static final HTMLSchema schema = new HTMLSchema();
 
     private @ColorInt int mDefaultStreamHeaderColor;
@@ -241,7 +242,7 @@ public class MessageAdapter extends ArrayAdapter<Message> {
                                         * scaleFactor * density));
                         return drawable;
                     } catch (IOException e) {
-                        Log.e("MessageAdapter", e.getMessage());
+                        Log.e(TAG, e.getMessage(), e);
                     }
                 }
                 return null;

--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -64,6 +64,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
         void clearChatBox();
     }
 
+    private static final String TAG = "MessageListFragment";
     private static final String PARAM_FILTER = "filter";
     NarrowFilter filter;
 
@@ -206,7 +207,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
 
                 } catch (NullPointerException e) {
                     Log.w("scrolling",
-                            "Could not find a location to scroll to!");
+                            "Could not find a location to scroll to!", e);
                 }
             }
         });
@@ -224,7 +225,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
                         app.setPointer(mID);
                     }
                 } catch (NullPointerException e) {
-                    Log.e("selected", "None, because we couldn't find the tag.");
+                    Log.e("selected", "None, because we couldn't find the tag.", e);
                 }
 
             }
@@ -246,6 +247,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
         try {
             mListener = (Listener) activity;
         } catch (ClassCastException e) {
+            Log.e(TAG, e.getMessage(), e);
             throw new ClassCastException(activity.toString()
                     + " must implement Listener");
         }

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
@@ -27,6 +27,7 @@ import com.zulip.android.activities.ZulipActivity;
 import com.zulip.android.ZulipApp;
 
 public class AsyncGetEvents extends Thread {
+    private static final String TAG = "AsyncGetEvents";
     public static final String ASYNC_GET_EVENTS = "asyncGetEvents";
     public static final String POINTER = "pointer";
     ZulipActivity activity;
@@ -143,7 +144,7 @@ public class AsyncGetEvents extends Thread {
                     }
                     backoff(e);
                 } catch (SocketTimeoutException e) {
-                    e.printStackTrace();
+                    Log.e(TAG, e.getMessage(), e);
                     // Retry without backoff, since it's already been a while
                 } catch (IOException e) {
                     if (request.aborting) {

--- a/app/src/main/java/com/zulip/android/networking/GravatarAsyncFetchTask.java
+++ b/app/src/main/java/com/zulip/android/networking/GravatarAsyncFetchTask.java
@@ -28,6 +28,7 @@ import com.zulip.android.activities.ZulipActivity;
  * Retrieves a user avatar (which may be a Gravatar) from the relevant server
  */
 public class GravatarAsyncFetchTask extends AsyncTask<URL, Void, Bitmap> {
+    private static final String TAG = "GravatarAsyncFetchTask";
     private final WeakReference<ImageView> imageViewReference;
     private Person person;
     private ZulipActivity context;
@@ -129,6 +130,7 @@ public class GravatarAsyncFetchTask extends AsyncTask<URL, Void, Bitmap> {
             try {
                 task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, url);
             } catch (NoSuchFieldError e) {
+                Log.e(TAG, e.getMessage(), e);
                 task.execute(url);
             }
         }

--- a/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
+++ b/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
@@ -23,6 +23,8 @@ import com.zulip.android.ZulipApp;
  */
 public class ZulipAsyncPushTask extends AsyncTask<String, String, String> {
 
+    private static final String TAG = "ZulipAsyncPushTask";
+
     public ZulipApp app;
     HTTPRequest request;
     AsyncTaskCompleteListener callback;
@@ -71,6 +73,7 @@ public class ZulipAsyncPushTask extends AsyncTask<String, String, String> {
         try {
             return this.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, method, url);
         } catch (NoSuchFieldError e) {
+            Log.e(TAG, e.getMessage(), e);
             return super.execute(method, url);
         }
     }

--- a/app/src/main/java/com/zulip/android/util/MD5Util.java
+++ b/app/src/main/java/com/zulip/android/util/MD5Util.java
@@ -1,5 +1,7 @@
 package com.zulip.android.util;
 
+import android.util.Log;
+
 import java.io.*;
 import java.security.*;
 
@@ -7,6 +9,8 @@ import java.security.*;
  * Gravatar example from http://en.gravatar.com/site/implement/images/java/
  */
 public class MD5Util {
+
+    private static final String TAG = "MD5Util";
 
     private MD5Util() {}
 
@@ -24,7 +28,9 @@ public class MD5Util {
             MessageDigest md = MessageDigest.getInstance("MD5");
             return hex(md.digest(message.getBytes("CP1252")));
         } catch (NoSuchAlgorithmException e) {
+            Log.e(TAG, e.getMessage(), e);
         } catch (UnsupportedEncodingException e) {
+            Log.e(TAG, e.getMessage(), e);
         }
         return null;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1166 - Exception handlers should preserve the original exception.
This pull request removes technical debt of 100 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1166
Please let me know if you have any questions.
George Kankava