### PR TITLE
squid:S2696 - Instance methods should not write to "static" fields

### DIFF
--- a/app/src/androidTest/java/com/zulip/android/activities/ChatBoxTest.java
+++ b/app/src/androidTest/java/com/zulip/android/activities/ChatBoxTest.java
@@ -41,8 +41,8 @@ public class ChatBoxTest extends BaseTest {
 
     @Before
     public void setUp() {
-        testMessageStream = (testMessageStream == null) ? RandomStringUtils.randomAlphanumeric(10) : testMessageStream;
-        testMessagePrivate = (testMessagePrivate == null) ? RandomStringUtils.randomAlphanumeric(15) : testMessagePrivate;
+        setTestMessageStream((testMessageStream == null) ? RandomStringUtils.randomAlphanumeric(10) : testMessageStream);
+        setTestMessagePrivate((testMessagePrivate == null) ? RandomStringUtils.randomAlphanumeric(15) : testMessagePrivate);
         if (ZulipApp.get().getApiKey() == null) {
             login();
         }
@@ -133,5 +133,21 @@ public class ChatBoxTest extends BaseTest {
                 return item.getType() == messageType && item.getContent().contains(text);
             }
         };
+    }
+
+    public static String getTestMessageStream() {
+        return testMessageStream;
+    }
+
+    public static void setTestMessageStream(String testMessageStream) {
+        ChatBoxTest.testMessageStream = testMessageStream;
+    }
+
+    public static String getTestMessagePrivate() {
+        return testMessagePrivate;
+    }
+
+    public static void setTestMessagePrivate(String testMessagePrivate) {
+        ChatBoxTest.testMessagePrivate = testMessagePrivate;
     }
 }

--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -79,7 +79,7 @@ public class ZulipApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        ZulipApp.instance = this;
+        ZulipApp.setInstance(this);
 
         // This used to be from HumbugActivity.getPreferences, so we keep that
         // file name.
@@ -331,5 +331,13 @@ public class ZulipApp extends Application {
 
     public Person getYou() {
         return you;
+    }
+
+    public static ZulipApp getInstance() {
+        return instance;
+    }
+
+    public static void setInstance(ZulipApp instance) {
+        ZulipApp.instance = instance;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2696 - Instance methods should not write to "static" fields.
This pull request removes technical debt of 60 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2696
Please let me know if you have any questions.
George Kankava