### PR TITLE
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
@@ -48,10 +48,14 @@ public class MessageAdapter extends ArrayAdapter<Message> {
 
     private static final HTMLSchema schema = new HTMLSchema();
 
-    private @ColorInt int mDefaultStreamHeaderColor;
-    private @ColorInt int mDefaultHuddleHeaderColor;
-    private @ColorInt int mDefaultStreamMessageColor;
-    private @ColorInt int mDefaultHuddleMessageColor;
+    @ColorInt
+    private int mDefaultStreamHeaderColor;
+    @ColorInt
+    private int mDefaultHuddleHeaderColor;
+    @ColorInt
+    private int mDefaultStreamMessageColor;
+    @ColorInt
+    private int mDefaultHuddleMessageColor;
 
     public MessageAdapter(Context context, List<Message> objects) {
         super(context, 0, objects);

--- a/app/src/main/java/com/zulip/android/gcm/Notifications.java
+++ b/app/src/main/java/com/zulip/android/gcm/Notifications.java
@@ -24,7 +24,7 @@ public class Notifications {
     // Project Number from the Google Cloud Services console
     private static final String SENDER_ID = "835904834568";
 
-    private final static int PLAY_SERVICES_RESOLUTION_REQUEST = 9000;
+    private static final int PLAY_SERVICES_RESOLUTION_REQUEST = 9000;
 
     static final String TAG = "GCM";
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
This pull request removes technical debt of 10 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
Please let me know if you have any questions.
George Kankava