### PR TITLE
squid:S3027 - String function use should be optimized for single characters

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -586,7 +586,7 @@ public class ZulipActivity extends FragmentActivity implements
                     public CharSequence convertToString(Cursor cursor) {
                         String text = topicActv.getText().toString();
                         String prefix;
-                        int lastIndex = text.lastIndexOf(",");
+                        int lastIndex = text.lastIndexOf(',');
                         if (lastIndex != -1) {
                             prefix = text.substring(0, lastIndex + 1);
                         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S3027 - String function use should be optimized for single characters.
This pull request removes technical debt of 5 minutes.
Please let me know if you have any questions.
George Kankava