### PR TITLE
squid:S00117 - Local variable and method parameter names should comply with a naming convention

### DIFF
--- a/app/src/androidTest/java/com/zulip/android/test/mutated/FakeAsyncGetOldMessages.java
+++ b/app/src/androidTest/java/com/zulip/android/test/mutated/FakeAsyncGetOldMessages.java
@@ -38,12 +38,12 @@ public class FakeAsyncGetOldMessages extends
     }
 
     @Override
-    protected boolean fetchMessages(int anchor, int num_before, int num_after,
+    protected boolean fetchMessages(int anchor, int numBefore, int numAfter,
             String[] params) {
         fmCalled = true;
         fmAnchor = anchor;
-        fmNumBefore = num_before;
-        fmNumAfter = num_after;
+        fmNumBefore = numBefore;
+        fmNumAfter = numAfter;
         if (appendTheseMessages != null) {
             this.receivedMessages.addAll(appendTheseMessages);
         }

--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -271,11 +271,11 @@ public class ZulipApp extends Application {
         return max_message_id;
     }
 
-    public void setMaxMessageId(int max_message_id) {
-        this.max_message_id = max_message_id;
+    public void setMaxMessageId(int maxMessageId) {
+        this.max_message_id = maxMessageId;
         if (settings != null) {
             Editor ed = settings.edit();
-            ed.putInt("max_message_id", max_message_id);
+            ed.putInt("max_message_id", maxMessageId);
             ed.apply();
         }
     }

--- a/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
@@ -77,7 +77,7 @@ public class MessageAdapter extends ArrayAdapter<Message> {
         }
 
         LinearLayout envelopeTile = (LinearLayout) tile.findViewById(R.id.envelopeTile);
-        TextView display_recipient = (TextView) tile.findViewById(R.id.displayRecipient);
+        TextView displayRecipient = (TextView) tile.findViewById(R.id.displayRecipient);
         ImageView muteImageView = (ImageView) tile.findViewById(R.id.muteMessageImage);
 
         if (message.getType() != MessageType.STREAM_MESSAGE) {
@@ -89,9 +89,9 @@ public class MessageAdapter extends ArrayAdapter<Message> {
         }
 
         if (message.getType() != MessageType.STREAM_MESSAGE) {
-            display_recipient.setText(context.getString(R.string.huddle_text, message.getDisplayRecipient(context.app)));
-            display_recipient.setTextColor(Color.WHITE);
-            display_recipient.setOnClickListener(new View.OnClickListener() {
+            displayRecipient.setText(context.getString(R.string.huddle_text, message.getDisplayRecipient(context.app)));
+            displayRecipient.setTextColor(Color.WHITE);
+            displayRecipient.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     if (getContext() instanceof NarrowListener) {
@@ -101,9 +101,9 @@ public class MessageAdapter extends ArrayAdapter<Message> {
                 }
             });
         } else {
-            display_recipient.setText(message.getDisplayRecipient(context.app));
-            display_recipient.setTextColor(Color.BLACK);
-            display_recipient.setOnClickListener(new View.OnClickListener() {
+            displayRecipient.setText(message.getDisplayRecipient(context.app));
+            displayRecipient.setTextColor(Color.BLACK);
+            displayRecipient.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     if (getContext() instanceof NarrowListener) {
@@ -181,10 +181,10 @@ public class MessageAdapter extends ArrayAdapter<Message> {
         }
 
         ImageView gravatar = (ImageView) tile.findViewById(R.id.gravatar);
-        Bitmap gravatar_img = context.getGravatars().get(message.getSender().getEmail());
-        if (gravatar_img != null) {
+        Bitmap gravatarImg = context.getGravatars().get(message.getSender().getEmail());
+        if (gravatarImg != null) {
             // Gravatar already exists for this image, set the ImageView to it
-            gravatar.setImageBitmap(gravatar_img);
+            gravatar.setImageBitmap(gravatarImg);
         } else {
             // Go get the Bitmap
             URL url = GravatarAsyncFetchTask.sizedURL(context, message.getSender().getAvatarURL(), 35);

--- a/app/src/main/java/com/zulip/android/models/MessageRange.java
+++ b/app/src/main/java/com/zulip/android/models/MessageRange.java
@@ -128,15 +128,15 @@ public class MessageRange extends BaseDaoEnabled<MessageRange, Integer> {
                         if (!ranges.isEmpty()) {
                             Log.i("", "our low: " + rng.low + ", our high: "
                                     + rng.high);
-                            int db_low = ranges.get(0).low;
-                            int db_high = ranges.get(ranges.size() - 1).high;
-                            Log.i("", "their low: " + db_low + ", their high: "
-                                    + db_high);
-                            if (db_low < rng.low) {
-                                rng.low = db_low;
+                            int dbLow = ranges.get(0).low;
+                            int dbHigh = ranges.get(ranges.size() - 1).high;
+                            Log.i("", "their low: " + dbLow + ", their high: "
+                                    + dbHigh);
+                            if (dbLow < rng.low) {
+                                rng.low = dbLow;
                             }
-                            if (db_high > rng.high) {
-                                rng.high = db_high;
+                            if (dbHigh > rng.high) {
+                                rng.high = dbHigh;
                             }
                             messageRangeDao.delete(ranges);
                         }

--- a/app/src/main/java/com/zulip/android/models/Person.java
+++ b/app/src/main/java/com/zulip/android/models/Person.java
@@ -102,8 +102,8 @@ public class Person {
      * @return the Person's realm.
      */
     public String getRealm() {
-        String[] split_email = this.getEmail().split("@");
-        return split_email[split_email.length - 1];
+        String[] splitEmail = this.getEmail().split("@");
+        return splitEmail[splitEmail.length - 1];
     }
 
     public boolean equals(Object obj) {

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetOldMessages.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetOldMessages.java
@@ -201,11 +201,11 @@ public class AsyncGetOldMessages extends ZulipAsyncPushTask {
 
     }
 
-    protected boolean fetchMessages(int anchor, int num_before, int num_after,
+    protected boolean fetchMessages(int anchor, int numBefore, int numAfter,
                                     String[] params) {
         this.setProperty("anchor", Integer.toString(anchor));
-        this.setProperty("num_before", Integer.toString(num_before));
-        this.setProperty("num_after", Integer.toString(num_after));
+        this.setProperty("num_before", Integer.toString(numBefore));
+        this.setProperty("num_after", Integer.toString(numAfter));
         this.setProperty("apply_markdown", "true");
 
         if (filter != null) {
@@ -256,14 +256,14 @@ public class AsyncGetOldMessages extends ZulipAsyncPushTask {
                 watch.stop();
                 Log.i("perf", "sqlite: messages " + watch.toString());
 
-                if (num_after == 0) {
+                if (numAfter == 0) {
                     receivedMessages.addAll(0, fetchedMessages);
                 } else {
                     receivedMessages.addAll(fetchedMessages);
                 }
 
                 if ((position == LoadPosition.ABOVE || position == LoadPosition.BELOW)
-                        && receivedMessages.size() < num_before + num_after) {
+                        && receivedMessages.size() < numBefore + numAfter) {
                     noFurtherMessages = true;
                 }
 

--- a/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
+++ b/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
@@ -91,9 +91,9 @@ public class ZulipAsyncPushTask extends AsyncTask<String, String, String> {
         this.request.setProperty(key, value);
     }
 
-    protected String doInBackground(String... api_path) {
+    protected String doInBackground(String... apiPath) {
         try {
-            return request.execute(api_path[0], api_path[1]);
+            return request.execute(apiPath[0], apiPath[1]);
         } catch (HttpResponseException e) {
             handleHTTPError(e);
         } catch (IOException e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
This pull request removes technical debt of 22 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00117
Please let me know if you have any questions.
George Kankava