### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -55,7 +55,7 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
         connectionProgressDialog = new ProgressDialog(this);
         connectionProgressDialog.setMessage(getString(R.string.signing_in));
 
-        mUseZulipCheckbox = ((CheckBox) findViewById(R.id.checkbox_usezulip));
+        mUseZulipCheckbox = (CheckBox) findViewById(R.id.checkbox_usezulip);
         mServerEditText = (EditText) findViewById(R.id.server_url);
         mGoogleSignInButton = findViewById(R.id.google_sign_in_button);
         findViewById(R.id.google_sign_in_button).setOnClickListener(this);

--- a/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageAdapter.java
@@ -96,7 +96,7 @@ public class MessageAdapter extends ArrayAdapter<Message> {
                 public void onClick(View v) {
                     if (getContext() instanceof NarrowListener) {
                         ((NarrowListener) getContext()).onNarrow(new NarrowFilterPM(
-                                Arrays.asList(message.getRecipients((ZulipApp.get())))));
+                                Arrays.asList(message.getRecipients(ZulipApp.get()))));
                     }
                 }
             });

--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -193,8 +193,8 @@ public class MessageListFragment extends Fragment implements MessageListener {
                 try {
                     // Scrolling messages isn't meaningful unless we have
                     // messages to scroll.
-                    Message message = ((Message) view.getItemAtPosition(view
-                            .getFirstVisiblePosition()));
+                    Message message = (Message) view.getItemAtPosition(view
+                            .getFirstVisiblePosition());
                     int mID = message.getID();
                     if (filter == null && app.getPointer() < mID) {
                         Log.i("scrolling", "Now at " + mID);

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -486,7 +486,7 @@ public class ZulipActivity extends FragmentActivity implements
             return;
         }
         sendingMessage(true);
-        MessageType messageType = (isCurrentModeStream()) ? MessageType.STREAM_MESSAGE : MessageType.PRIVATE_MESSAGE;
+        MessageType messageType = isCurrentModeStream() ? MessageType.STREAM_MESSAGE : MessageType.PRIVATE_MESSAGE;
         Message msg = new Message(app);
         msg.setSender(app.getYou());
 
@@ -690,7 +690,7 @@ public class ZulipActivity extends FragmentActivity implements
 
     public boolean isCurrentModeStream() {
         //The TextView is VISIBLE which means currently send to stream is on.
-        return (textView.getVisibility() == View.VISIBLE);
+        return textView.getVisibility() == View.VISIBLE;
     }
 
     public void removeEditTextErrors() {

--- a/app/src/main/java/com/zulip/android/gcm/GcmShowNotificationReceiver.java
+++ b/app/src/main/java/com/zulip/android/gcm/GcmShowNotificationReceiver.java
@@ -14,7 +14,7 @@ public class GcmShowNotificationReceiver extends WakefulBroadcastReceiver {
                 GcmIntentService.class.getName());
 
         // Start the service, keeping the device awake while it is launching.
-        startWakefulService(context, (intent.setComponent(comp)));
+        startWakefulService(context, intent.setComponent(comp));
     }
 
 }

--- a/app/src/main/java/com/zulip/android/models/Person.java
+++ b/app/src/main/java/com/zulip/android/models/Person.java
@@ -117,8 +117,8 @@ public class Person {
             return false;
         }
         Person per = (Person) obj;
-        return (this.name.equals(per.getName()) && this.email.equals(per
-                .getEmail()));
+        return this.name.equals(per.getName()) && this.email.equals(per
+                .getEmail());
     }
 
     public int hashCode() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
This pull request removes technical debt of 7 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava