### PR TITLE
Fix up parsing for user specified endpoint

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -120,7 +120,7 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
         // if does not begin with "api.zulip.com" and if the path is empty, use "/api" as first segment in the path
         List<String> paths = serverUri.getPathSegments();
         if (!serverUri.getHost().startsWith("api.") && paths.isEmpty()) {
-            serverUri = serverUri.buildUpon().appendPath("api").build();
+            serverUri = serverUri.buildUpon().appendEncodedPath("api/").build();
         }
 
         ((ZulipApp) getApplication()).setServerURL(serverUri.toString());

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -107,14 +107,14 @@ public class LoginActivity extends FragmentActivity implements View.OnClickListe
             mServerEditText.setError(getString(errorMessage));
         }
 
-        // add https if scheme is not included
+        // add http if scheme is not included
         if (!serverURL.contains("://")) {
-            serverURL = "https://" + serverURL;
+            serverURL = "http://" + serverURL;
         }
 
         Uri serverUri = Uri.parse(serverURL);
         if (serverUri.isRelative()) {
-            serverUri = serverUri.buildUpon().scheme("https").build();
+            serverUri = serverUri.buildUpon().scheme("http").build();
         }
 
         // if does not begin with "api.zulip.com" and if the path is empty, use "/api" as first segment in the path


### PR DESCRIPTION
This fixes up a few issues with the parsing for a user-specified domain (not zulip.com).

1) It defaults to http if a scheme is not specified
2) It now correctly appends a `/` to the end of the API endpoint (if needed)