### PR TITLE
Fixes: #132 Show Title and name in header if narrowed to self PM's

### DIFF
--- a/app/src/main/java/com/zulip/android/filters/NarrowFilterPM.java
+++ b/app/src/main/java/com/zulip/android/filters/NarrowFilterPM.java
@@ -74,7 +74,7 @@ public class NarrowFilterPM implements NarrowFilter {
     public String getTitle() {
         ArrayList<String> names = new ArrayList<>();
         for (Person person : people) {
-            if (!person.equals(ZulipApp.get().getYou())) {
+            if (!person.equals(ZulipApp.get().getYou()) || people.size() == 1) { //If PM to self then show title as your name
                 names.add(person.getName());
             }
         }

--- a/app/src/main/java/com/zulip/android/models/Message.java
+++ b/app/src/main/java/com/zulip/android/models/Message.java
@@ -231,7 +231,7 @@ public class Message {
 
     /**
      * Constructs a pretty-printable-to-the-user string consisting of the names
-     * of all of the participants in the message, minus you.
+     * of all of the participants in the message.
      * <p/>
      * For MessageType.STREAM_MESSAGE, return the stream name instead.
      *
@@ -246,13 +246,14 @@ public class Message {
             ArrayList<String> names = new ArrayList<>();
 
             for (Person person : people) {
-                if (person.id != app.getYou().id) {
+                if (person.id != app.getYou().id || people.length == 1) {
                     names.add(person.getName());
                 }
             }
             return TextUtils.join(", ", names);
         }
     }
+
 
     /**
      * Creates a comma-separated String of the email addressed of all the


### PR DESCRIPTION
I have also checked this function https://github.com/kunall17/zulip-android/blob/43fef77636256b2f7ec51d560f0c7f6aa35be88c/app/src/main/java/com/zulip/android/models/Message.java#L241 which is being edited in this PR, is only used in this binding the Recipent Bar.