### PR TITLE
Fixes #131: Wrong messages order 

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -343,7 +343,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
         int topPosBefore = linearLayoutManager.findFirstVisibleItemPosition();
         int addedCount = 0;
         int headerParents = 0;
-
+        StringBuilder stringBuilder = new StringBuilder ();
         if (pos == LoadPosition.NEW && !loadedToBottom) {
             // If we don't have intermediate messages loaded, don't add new
             // messages -- they'll be loaded when we scroll down.
@@ -383,7 +383,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
                 this.adapter.addNewMessage(message);
                 messageList.add(message);
             } else if (pos == LoadPosition.ABOVE || pos == LoadPosition.INITIAL) {
-                headerParents = (this.adapter.addMessage(message, addedCount + headerParents)) ? headerParents + 1 : headerParents;
+                headerParents = (this.adapter.addOldMessage(message, addedCount + headerParents, stringBuilder)) ? headerParents + 1 : headerParents;
                 messageList.add(addedCount, message);
                 addedCount++;
             }

--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -372,7 +372,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
             if (stream != null && filter == null) { //Filter muted messages only in homescreen.
                 if (app.isTopicMute(message)) {
                     mListener.addToList(message);
-                    return;
+                    continue;
                 }
             }
             if (filter == null && stream != null && !stream.getInHomeView()) {

--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -44,11 +44,11 @@ import java.util.List;
  * Each Message is inserted to its MessageHeader which are distinguished by the {@link Message#getIdForHolder()}
  * saved in {@link MessageHeaderParent#getId()}
  *
- * There are two ways to insert a message in this adapter one {@link RecyclerMessageAdapter#addMessage(Message, int)}
+ * There are two ways to insert a message in this adapter one {@link RecyclerMessageAdapter#addOldMessage(Message, int, StringBuilder)}
  * and second one {@link RecyclerMessageAdapter#addNewMessage(Message)}
  * The first one is used to add old messages from the databases with {@link com.zulip.android.util.MessageListener.LoadPosition#BELOW}
- * and {@link com.zulip.android.util.MessageListener.LoadPosition#INITIAL}. This is for the threaded view and the messages are added
- * to the existing messageHeaderParents.
+ * and {@link com.zulip.android.util.MessageListener.LoadPosition#INITIAL}. Messages are added from 1st index of the adapter and new
+ * headerParents are created if it doesn't matches the current header where the adding is being placed, this is done to match the UI as the web.
  * In addNewMessages the messages are loaded in the bottom and new headers are created if it does not matches the last header.
  */
 public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
@@ -233,6 +233,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
      * messageHeader is found then create a new messageHeader
      * @param message Message to be added
      * @param messageAndHeadersCount Count of the (messages + messageHeaderParent) added in the loop from where this function is being called
+     * @param lastHolderId This is StringBuilder so as to make pass by reference work, the new lastHolderId is saved here if the value changes
      * @return returns true if a new messageHeaderParent is created for this message so as to increment the count by where this function is being called.
      */
     public boolean addOldMessage(Message message, int messageAndHeadersCount, StringBuilder lastHolderId) {


### PR DESCRIPTION
Currently [this](https://github.com/zulip/zulip-android/blob/master/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java#L163) was adding messages before another MessageHeaderParent now this thing is fixed and comparing ID's now! 

Commit 2ef8d48: Shows all the messages of today at the bottom as new messages even if the app pointer is greater than this messageId.

The [code used ](https://github.com/zulip/zulip-android/pull/141/files#diff-1dded4e9deaa29c6eb8becf0bb2fee03R54) in creating [espresso test](https://github.com/zulip/zulip-android/pull/141) were very useful I used them to debug the order + if they are included in the correct messageHeaders. 

I have created a [**temporary patch**](https://github.com/zulip/zulip-android/files/428902/checkOrder.and.messageHeaderParent.zip) for espresso code just for debugging purpose of this branch what this does is it invokes both the methods to check the message order according to ID's and second one checks if the messages are inserted below the correct messageHeader.
This works if we go to overflow menu and press the Refresh menuItem.
If throws some errors in the log then it means there are still bugs! else it will print the information about the Id's and headerParents ID's