### PR TITLE
Fix for Crashlytics non-fatal crash on fetching old messages

### DIFF
--- a/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
+++ b/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
@@ -106,7 +106,7 @@ public abstract class ZulipAsyncPushTask extends AsyncTask<String, String, Strin
             ZLog.logException(e);
             this.cancel(true);
         }
-        return "";
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Fix regarding this issue: https://fabric.io/zulip2/android/apps/com.zulip.android/issues/57b6191dffcdc04250e3e5fe

Cause of issue: https://github.com/zulip/zulip-android/blob/master/app/src/main/java/com/zulip/android/networking/AsyncGetOldMessages.java#L228