### PR TITLE
Synchronize aborts

### DIFF
--- a/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
+++ b/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
@@ -5,6 +5,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.util.Log;
 
+import com.crashlytics.android.Crashlytics;
 import com.zulip.android.ZulipApp;
 import com.zulip.android.util.ZLog;
 
@@ -90,6 +91,8 @@ public abstract class ZulipAsyncPushTask extends AsyncTask<String, String, Strin
     }
 
     protected String doInBackground(String... api_path) {
+        Crashlytics.log(Log.VERBOSE, "Network call", getClass().getCanonicalName() + request);
+        
         try {
             Response response = request.execute();
             String responseString = response.body().string();


### PR DESCRIPTION
Fix attempting to nip in bud possible race conditions and catching possible illegal state exceptions. Only one crash, nothing major. 

https://fabric.io/zulip2/android/apps/com.zulip.android/issues/57bb9cdeffcdc0425018ab04