### PR TITLE
Refactor Muted Topics into a single class

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -32,6 +32,7 @@ import com.zulip.android.models.Stream;
 import com.zulip.android.networking.AsyncGetOldMessages;
 import com.zulip.android.networking.ZulipAsyncPushTask;
 import com.zulip.android.util.MessageListener;
+import com.zulip.android.util.MutedTopics;
 import com.zulip.android.viewholders.HeaderSpaceItemDecoration;
 
 import org.json.JSONObject;
@@ -48,6 +49,7 @@ import java.util.List;
 public class MessageListFragment extends Fragment implements MessageListener {
     private static final int PIXEL_OFFSET_MESSAGE_HEADERS = 24;
     private LinearLayoutManager linearLayoutManager;
+    private MutedTopics mMutedTopics;
 
     /**
      * This interface must be implemented by activities that contain this
@@ -62,8 +64,6 @@ public class MessageListFragment extends Fragment implements MessageListener {
         void onListResume(MessageListFragment f);
 
         void addToList(Message message);
-
-        void muteTopic(Message message);
 
         void recyclerViewScrolled();
 
@@ -97,6 +97,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
 
     public MessageListFragment() {
         app = ZulipApp.get();
+        mMutedTopics = MutedTopics.get();
         // Required empty public constructor
     }
 
@@ -370,7 +371,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
             Stream stream = message.getStream();
 
             if (stream != null && filter == null) { //Filter muted messages only in homescreen.
-                if (app.isTopicMute(message)) {
+                if (mMutedTopics.isTopicMute(message)) {
                     mListener.addToList(message);
                     continue;
                 }

--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -29,6 +29,7 @@ import com.zulip.android.models.Message;
 import com.zulip.android.models.MessageType;
 import com.zulip.android.models.Person;
 import com.zulip.android.models.Stream;
+import com.zulip.android.util.MutedTopics;
 import com.zulip.android.util.OnItemClickListener;
 import com.zulip.android.util.ZLog;
 import com.zulip.android.viewholders.LoadingHolder;
@@ -63,6 +64,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     private static String privateHuddleText;
     private List<Object> items;
     private ZulipApp zulipApp;
+    private MutedTopics mMutedTopics;
     private Context context;
     private NarrowListener narrowListener;
     private static final float HEIGHT_IN_DP = 48;
@@ -91,6 +93,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
         super();
         items = new ArrayList<>();
         zulipApp = ZulipApp.get();
+        mMutedTopics = MutedTopics.get();
         this.context = context;
         narrowListener = (NarrowListener) context;
         this.startedFromFilter = startedFromFilter;
@@ -245,7 +248,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             messageHeaderParent.setMessageType(message.getType());
             messageHeaderParent.setDisplayRecipent(message.getDisplayRecipient(zulipApp));
             if (message.getType() == MessageType.STREAM_MESSAGE) {
-                messageHeaderParent.setMute(zulipApp.isTopicMute(message));
+                messageHeaderParent.setMute(mMutedTopics.isTopicMute(message));
             }
             messageHeaderParent.setColor((message.getStream() == null) ? mDefaultStreamHeaderColor : message.getStream().getParsedColor());
             items.add(messageAndHeadersCount + 1, messageHeaderParent); //1 for LoadingHeader
@@ -285,7 +288,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             item.setMessageType(message.getType());
             item.setDisplayRecipent(message.getDisplayRecipient(zulipApp));
             if (message.getType() == MessageType.STREAM_MESSAGE)
-                item.setMute(zulipApp.isTopicMute(message));
+                item.setMute(mMutedTopics.isTopicMute(message));
             item.setColor((message.getStream() == null) ? mDefaultStreamHeaderColor : message.getStream().getParsedColor());
             items.add(getItemCount(true) - 1, item);
             notifyItemInserted(getItemCount(true) - 1);

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -90,6 +90,7 @@ import com.zulip.android.networking.ZulipInterceptor;
 import com.zulip.android.networking.response.UserConfigurationResponse;
 import com.zulip.android.service.ZulipServices;
 import com.zulip.android.util.AnimationHelper;
+import com.zulip.android.util.MutedTopics;
 import com.zulip.android.util.SwipeRemoveLinearLayout;
 import com.zulip.android.util.ZLog;
 import com.zulip.android.ZulipApp;
@@ -164,6 +165,8 @@ public class ZulipActivity extends BaseActivity implements
     private SimpleCursorAdapter subjectActvAdapter;
     private SimpleCursorAdapter emailActvAdapter;
     private AppBarLayout appBarLayout;
+
+    private MutedTopics mMutedTopics;
 
     private BroadcastReceiver onGcmMessage = new BroadcastReceiver() {
         public void onReceive(Context contenxt, Intent intent) {
@@ -240,24 +243,6 @@ public class ZulipActivity extends BaseActivity implements
     }
 
     @Override
-    public void muteTopic(Message message) {
-        app.muteTopic(message);
-        for (int i = homeList.adapter.getItemCount() - 1; i >= 0; i--) {
-            Object object = homeList.adapter.getItem(i);
-            if (object instanceof Message) {
-                Message msg = (Message) object;
-                if (msg.getStream() != null
-                        && msg.getStream().getId() == message.getStream().getId()
-                        && msg.getSubject().equals(message.getSubject())) {
-                    mutedTopics.add(msg);
-                    homeList.adapter.remove(msg);
-                }
-            }
-        }
-        homeList.adapter.notifyDataSetChanged();
-    }
-
-    @Override
     public void recyclerViewScrolled() {
         if (chatBox.getVisibility() == View.VISIBLE && !isTextFieldFocused) {
             displayChatBox(false);
@@ -280,6 +265,9 @@ public class ZulipActivity extends BaseActivity implements
 
         app = (ZulipApp) getApplicationContext();
         settings = app.getSettings();
+        if (mMutedTopics == null) {
+            mMutedTopics = MutedTopics.get();
+        }
 
         processParams();
 
@@ -770,7 +758,7 @@ public class ZulipActivity extends BaseActivity implements
                     case R.id.name_child:
                         TextView name_child = (TextView) view;
                         name_child.setText(cursor.getString(columnIndex));
-                        if (app.isTopicMute(cursor.getInt(1), cursor.getString(columnIndex))) {
+                        if (mMutedTopics.isTopicMute(cursor.getInt(1), cursor.getString(columnIndex))) {
                             name_child.setTextColor(ContextCompat.getColor(ZulipActivity.this, R.color.colorTextSecondary));
                         }
                         return true;

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
@@ -16,6 +16,7 @@ import com.zulip.android.networking.response.UserConfigurationResponse;
 import com.zulip.android.networking.response.events.EventsBranch;
 import com.zulip.android.networking.response.events.GetEventResponse;
 import com.zulip.android.networking.response.events.MessageWrapper;
+import com.zulip.android.util.MutedTopics;
 import com.zulip.android.util.TypeSwapper;
 import com.zulip.android.util.ZLog;
 import com.zulip.android.widget.ZulipWidget;
@@ -44,6 +45,7 @@ public class AsyncGetEvents extends Thread {
     private ZulipApp app;
     private static int interval = 1000;
     private boolean calledFromWidget = false;
+    private MutedTopics mMutedTopics;
 
     private boolean keepThisRunning = true;
     private HTTPRequest request;
@@ -66,6 +68,7 @@ public class AsyncGetEvents extends Thread {
         request = new HTTPRequest(app);
         calledFromWidget = true;
         this.interval = interval;
+        mMutedTopics = MutedTopics.get();
     }
 
     public void start() {
@@ -144,7 +147,7 @@ public class AsyncGetEvents extends Thread {
                         }
                     }
                     //MUST UPDATE AFTER SUBSCRIPTIONS ARE STORED IN DB
-                    app.addToMutedTopics(response.getMutedTopics());
+                    mMutedTopics.addToMutedTopics(response.getMutedTopics());
 
                     // Get people
                     List<Person> people = response.getRealmUsers();

--- a/app/src/main/java/com/zulip/android/util/MutedTopics.java
+++ b/app/src/main/java/com/zulip/android/util/MutedTopics.java
@@ -1,0 +1,60 @@
+package com.zulip.android.util;
+
+import android.content.SharedPreferences;
+
+import com.zulip.android.ZulipApp;
+import com.zulip.android.models.Message;
+import com.zulip.android.models.Stream;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+public class MutedTopics {
+
+    private Set<String> mutedTopics;
+    private static final String MUTED_TOPIC_KEY = "mutedTopics";
+
+    public MutedTopics() {
+        mutedTopics = new HashSet<>(getPrefs().getStringSet(MUTED_TOPIC_KEY, new HashSet<String>()));
+    }
+
+    public void addToMutedTopics(List<List<String>> mutedTopics) {
+        Stream stream;
+
+        if(mutedTopics != null) {
+            for (int i = 0; i < mutedTopics.size(); i++) {
+                List<String> mutedTopic = mutedTopics.get(i);
+                stream = Stream.getByName(ZulipApp.get(), mutedTopic.get(0));
+                this.mutedTopics.add(stream.getId() + mutedTopic.get(1));
+            }
+        }
+
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.putStringSet(MUTED_TOPIC_KEY, new HashSet<>(this.mutedTopics));
+        editor.apply();
+    }
+
+    public boolean isTopicMute(int id, String subject) {
+        return mutedTopics.contains(id + subject);
+    }
+
+    public boolean isTopicMute(Message message) {
+        return mutedTopics.contains(message.concatStreamAndTopic());
+    }
+
+    public void muteTopic(Message message) {
+        mutedTopics.add(message.concatStreamAndTopic());
+
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.putStringSet(MUTED_TOPIC_KEY, new HashSet<>(mutedTopics));
+        editor.apply();
+    }
+
+    private SharedPreferences getPrefs() {
+        return ZulipApp.get().getSettings();
+    }
+
+
+}

--- a/app/src/main/java/com/zulip/android/util/MutedTopics.java
+++ b/app/src/main/java/com/zulip/android/util/MutedTopics.java
@@ -8,48 +8,47 @@ import com.zulip.android.models.Stream;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 
 public class MutedTopics {
 
-    private Set<String> mutedTopics;
     private static final String MUTED_TOPIC_KEY = "mutedTopics";
 
-    public MutedTopics() {
-        mutedTopics = new HashSet<>(getPrefs().getStringSet(MUTED_TOPIC_KEY, new HashSet<String>()));
+    private static MutedTopics sMutedTopics;
+
+    private MutedTopics() { }
+
+    public static MutedTopics get() {
+        if (sMutedTopics == null) {
+            sMutedTopics = new MutedTopics();
+        }
+        return sMutedTopics;
     }
 
     public void addToMutedTopics(List<List<String>> mutedTopics) {
-        Stream stream;
+        if (mutedTopics == null) return;
 
-        if(mutedTopics != null) {
-            for (int i = 0; i < mutedTopics.size(); i++) {
-                List<String> mutedTopic = mutedTopics.get(i);
-                stream = Stream.getByName(ZulipApp.get(), mutedTopic.get(0));
-                this.mutedTopics.add(stream.getId() + mutedTopic.get(1));
-            }
+        Stream stream;
+        HashSet<String> topics = new HashSet<>();
+
+        for (int i = 0; i < mutedTopics.size(); i++) {
+            List<String> mutedTopic = mutedTopics.get(i);
+            stream = Stream.getByName(ZulipApp.get(), mutedTopic.get(0));
+            topics.add(stream.getId() + mutedTopic.get(1));
         }
 
         SharedPreferences.Editor editor = getPrefs().edit();
-        editor.putStringSet(MUTED_TOPIC_KEY, new HashSet<>(this.mutedTopics));
+        editor.putStringSet(MUTED_TOPIC_KEY, topics);
         editor.apply();
     }
 
     public boolean isTopicMute(int id, String subject) {
-        return mutedTopics.contains(id + subject);
+        String mutedTopicKey = String.valueOf(id) + subject;
+        return getPrefs().getStringSet(MUTED_TOPIC_KEY, new HashSet<String>()).contains(mutedTopicKey);
     }
 
     public boolean isTopicMute(Message message) {
-        return mutedTopics.contains(message.concatStreamAndTopic());
-    }
-
-    public void muteTopic(Message message) {
-        mutedTopics.add(message.concatStreamAndTopic());
-
-        SharedPreferences.Editor editor = getPrefs().edit();
-        editor.putStringSet(MUTED_TOPIC_KEY, new HashSet<>(mutedTopics));
-        editor.apply();
+        return getPrefs().getStringSet(MUTED_TOPIC_KEY, new HashSet<String>()).contains(message.concatStreamAndTopic());
     }
 
     private SharedPreferences getPrefs() {

--- a/app/src/main/java/com/zulip/android/widget/ZulipWidget.java
+++ b/app/src/main/java/com/zulip/android/widget/ZulipWidget.java
@@ -76,7 +76,7 @@ public class ZulipWidget extends AppWidgetProvider {
     }
 
     private static void setupGetEvents() {
-        asyncGetEvents = new AsyncGetEvents(ZulipApp.get(), intervalMilliseconds);
+        asyncGetEvents = new AsyncGetEvents(intervalMilliseconds);
         asyncGetEvents.start();
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'com.google.gms:google-services:2.1.0'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 13 14:55:11 EDT 2016
+#Thu Sep 22 12:18:08 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
Consolidating logic for Muted Topics into a single class, removing it from the startup path in ZulipApplication onCreate.

Also includes upgrade to Gradle packages.