### PR TITLE
Add missing @FormUrlEncoded annotation in ZulipServices interface

### DIFF
--- a/app/src/main/java/com/zulip/android/service/ZulipServices.java
+++ b/app/src/main/java/com/zulip/android/service/ZulipServices.java
@@ -48,6 +48,7 @@ public interface ZulipServices {
     @POST("v1/fetch_api_key")
     Call<LoginResponse> login(@Field("username") String username, @Field("password") String password);
 
+    @FormUrlEncoded
     @POST("v1/dev_fetch_api_key")
     Call<LoginResponse> loginDEV(@Field("username") String username);
 


### PR DESCRIPTION
**Edited**
Form-encoded data is sent when `@FormUrlEncoded` is present on the method. Each key-value pair is annotated with `@Field` containing the name and the object providing the value.
It seems that `@FormUrlEncoded` was missing for the method `loginDEV`, because of which we were getting this issue #189 