### PR TITLE
Fixes: #187 Ask for HTTP/HTTPS for non-prod builds

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -160,7 +160,8 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
         // add http or https if scheme is not included
         if (!serverURL.contains("://")) {
             serverURL = httpScheme + "://" + serverURL;
-            showBackends(httpScheme, serverURL);
+            if (BuildConfig.DEBUG) showHTTPDialog(serverURL); //Ask for http or https if in non-prod builds otherwise if in prod then use https
+            else showBackends(httpScheme, serverURL);
         } else {
             Uri serverUri = Uri.parse(serverURL);
 
@@ -227,7 +228,7 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
     private void showHTTPDialog(final String serverURL) {
         new AlertDialog.Builder(this)
                 .setTitle(R.string.http_or_https)
-                .setMessage(R.string.http_message)
+                .setMessage(((BuildConfig.DEBUG) ? R.string.http_message_debug : R.string.http_message))
                 .setPositiveButton(R.string.use_https, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int which) {
                         dialog.dismiss();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,7 @@
     <string name="menu_today">Today</string>
     <string name="http_or_https">HTTP/HTTPS</string>
     <string name="http_message">HTTP is insecure, and we recommend using it only for testing the Zulip Android app against a development environment. Are you sure you want to use HTTP?</string>
+    <string name="http_message_debug">Which scheme you would like to use HTTP or HTTPS?</string>
     <string name="use_https">Use HTTPS</string>
     <string name="use_http">Use HTTP</string>
     <string name="empty_list">Sorry, no messages here.</string>


### PR DESCRIPTION
Fix for #185 
A small fix for the HTTP/HTTPS default in debug mode! 
This asks the user if HTTP/HTTPS scheme if not specified in non-prod builds!