### PR TITLE
Crash fix for null reference bug

### DIFF
--- a/app/src/main/java/com/zulip/android/models/Person.java
+++ b/app/src/main/java/com/zulip/android/models/Person.java
@@ -138,6 +138,8 @@ public class Person {
             return false;
         }
         Person per = (Person) obj;
+        if(this.name == null || this.email == null)
+            return false;
         return this.name.equals(per.getName()) && this.email.equals(per
                 .getEmail());
     }


### PR DESCRIPTION
App crashes on clicking on a message, click back and reopening the app.
![screenshot from 2016-10-01 17 19 56](https://cloud.githubusercontent.com/assets/9164477/19016629/a0baf772-883d-11e6-8abb-f079de3af5a9.png)
