### PR TITLE
Update pointer and read flags

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -151,7 +151,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
         recyclerView = (RecyclerView) view.findViewById(R.id.recyclerView);
         linearLayoutManager = new LinearLayoutManager(getContext());
         recyclerView.setLayoutManager(linearLayoutManager);
-        adapter = new RecyclerMessageAdapter(messageList, getActivity(), (filter == null));
+        adapter = new RecyclerMessageAdapter(messageList, getActivity(), (filter != null));
         recyclerView.addItemDecoration(new HeaderSpaceItemDecoration(PIXEL_OFFSET_MESSAGE_HEADERS, getContext()));
         recyclerView.setAdapter(adapter);
         registerForContextMenu(recyclerView);

--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -380,7 +380,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     @Override
     public void onViewAttachedToWindow(RecyclerView.ViewHolder holder) {
         super.onViewRecycled(holder);
-        if (holder.getItemViewType() == VIEWTYPE_MESSAGE)
+        if (holder.getItemViewType() == VIEWTYPE_MESSAGE && !startedFromFilter)
             markThisMessageAsRead((Message) getItem(holder.getAdapterPosition()));
     }
 
@@ -391,10 +391,15 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     private void markThisMessageAsRead(Message message) {
         try {
             int mID = message.getID();
-            if (!startedFromFilter && zulipApp.getPointer() < mID) {
+            if (zulipApp.getPointer() < mID) {
                 zulipApp.syncPointer(mID);
             }
-            if (!message.getMessageRead()) {
+
+            boolean isMessageRead = false;
+            if (message.getMessageRead() != null) {
+                isMessageRead = message.getMessageRead();
+            }
+            if (!isMessageRead) {
                 try {
                     updateBuilder.where().eq(Message.ID_FIELD, message.getID());
                     updateBuilder.updateColumnValue(Message.MESSAGE_READ_FIELD, true);


### PR DESCRIPTION
When `filter != null` then , `startedFromFilter` should be true. This will successfully update the pointers in HomeView.
Also, initially `message.getMessageRead` returns `null` and hence throws an exception
> attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()  on a null object reference

Due to this runtime exception, the control never reaches `zulipApp.markMessageAsRead(message)` 
Hence to avoid this, I have used `isMessageRead` boolean which is set to false if `message.getMessageRead()` is null or false and true if `message.getMessageRead()` is true.