### PR TITLE
Fixup blank avatars and senders

### DIFF
--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -340,6 +340,16 @@ public class ZulipApp extends Application {
         return settings.getString("server_url", DEFAULT_SERVER_URL);
     }
 
+    public String getServerHostUri() {
+        String uri = settings.getString("server_url", DEFAULT_SERVER_URL);
+        if (uri.contains("/api/")) {
+            uri = uri.replace("/api/", "/");
+        } else if (uri.contains("/api.")) {
+            uri = uri.replace("/api.", "/");
+        }
+        return uri;
+    }
+
     public String getApiKey() {
         return api_key;
     }

--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -33,6 +33,7 @@ import com.zulip.android.models.Person;
 import com.zulip.android.models.Stream;
 import com.zulip.android.util.MutedTopics;
 import com.zulip.android.util.OnItemClickListener;
+import com.zulip.android.util.UrlHelper;
 import com.zulip.android.util.ZLog;
 import com.zulip.android.viewholders.LoadingHolder;
 import com.zulip.android.viewholders.MessageHeaderParent;
@@ -442,7 +443,10 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             Resources resources = context.getResources();
             float px = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
                     35, resources.getDisplayMetrics());
+
+
             String url = message.getSender().getAvatarURL() + "&s=" + px;
+            url = UrlHelper.addHost(url);
 
             Picasso.with(context)
                     .load(url)

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetOldMessages.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetOldMessages.java
@@ -69,16 +69,13 @@ public class AsyncGetOldMessages extends ZulipAsyncPushTask {
     @Override
     protected String doInBackground(String... params) {
         // Lets see whether we have this cached already
-        final RuntimeExceptionDao<MessageRange, Integer> messageRangeDao = app
-                .getDao(MessageRange.class);
-        RuntimeExceptionDao<Message, Object> messageDao = app
-                .getDao(Message.class);
+        final RuntimeExceptionDao<MessageRange, Integer> messageRangeDao = app.getDao(MessageRange.class);
+        RuntimeExceptionDao<Message, Object> messageDao = app.getDao(Message.class);
         messageDao.setObjectCache(true);
         try {
             if (rng == null) {
                 // We haven't been passed a range, see if we have a range cached
-                MessageRange protoRng = MessageRange.getRangeContaining(
-                        mainAnchor, messageRangeDao);
+                MessageRange protoRng = MessageRange.getRangeContaining(mainAnchor, messageRangeDao);
                 Log.i("AGOM", "rng retreived");
                 if (protoRng != null) {
 

--- a/app/src/main/java/com/zulip/android/util/UrlHelper.java
+++ b/app/src/main/java/com/zulip/android/util/UrlHelper.java
@@ -1,0 +1,14 @@
+package com.zulip.android.util;
+
+import com.zulip.android.ZulipApp;
+
+public class UrlHelper {
+
+    public static String addHost(String url) {
+        if (!url.startsWith("http")) {
+            url = ZulipApp.get().getServerHostUri() + url;
+        }
+
+       return url;
+    }
+}


### PR DESCRIPTION
There's been a persistent issue with avatars and sometime sender names appearing as blank in the app.  This fixes both these issues by 

1) Properly serializing the Sender data in the Message object before writing it to the DAO &
2) Prefixing path-only avatar urls with the server domain