### PR TITLE
Logout user from Google Auth as well

### DIFF
--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -36,6 +36,7 @@ import com.zulip.android.networking.ZulipInterceptor;
 import com.zulip.android.networking.response.UserConfigurationResponse;
 import com.zulip.android.networking.response.events.EventsBranch;
 import com.zulip.android.service.ZulipServices;
+import com.zulip.android.util.GoogleAuthHelper;
 import com.zulip.android.util.ZLog;
 
 import java.io.IOException;
@@ -398,6 +399,8 @@ public class ZulipApp extends Application {
         ed.apply();
         this.api_key = null;
         setEventQueueId(null);
+
+        new GoogleAuthHelper().logOutGoogleAuth();
     }
 
     public String getEmail() {
@@ -527,4 +530,5 @@ public class ZulipApp extends Application {
             }
         });
     }
+
 }

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -346,6 +346,7 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
                     .build();
 
             mGoogleApiClient.connect();
+
             allowUserToPickAccount();
         } else {
             allowUserToPickAccount();

--- a/app/src/main/java/com/zulip/android/util/GoogleAuthHelper.java
+++ b/app/src/main/java/com/zulip/android/util/GoogleAuthHelper.java
@@ -1,0 +1,44 @@
+package com.zulip.android.util;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.google.android.gms.auth.api.Auth;
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.zulip.android.BuildConfig;
+import com.zulip.android.ZulipApp;
+
+/**
+ * Class to encapsulate logic for the Google Authentication flows
+ */
+
+public class GoogleAuthHelper implements GoogleApiClient.ConnectionCallbacks {
+
+    private GoogleApiClient mGoogleApiClient;
+
+    public void logOutGoogleAuth() {
+        GoogleSignInOptions googleSignInOptions = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                .requestEmail()
+                .requestIdToken(BuildConfig.GOOGLE_CLIENT_ID)
+                .build();
+
+        mGoogleApiClient = new GoogleApiClient.Builder(ZulipApp.get())
+                .addApi(Auth.GOOGLE_SIGN_IN_API, googleSignInOptions)
+                .addConnectionCallbacks(this)
+                .build();
+
+        mGoogleApiClient.connect();
+    }
+
+    @Override
+    public void onConnected(@Nullable Bundle bundle) {
+        Auth.GoogleSignInApi.signOut(mGoogleApiClient);
+    }
+
+    @Override
+    public void onConnectionSuspended(int i) {
+        // do nothing
+    }
+}


### PR DESCRIPTION
Currently if you login using Google Sign In, and then log out, you will not be presented with the menu of Google accounts to choose from.  This PR logs you out from Google Auth, which will make the google sign in account menu appear on sign in the next time.