### PR TITLE
Register app as a way to share images

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <permission
         android:name="${applicationId}.permission.C2D_MESSAGE"
@@ -31,6 +32,11 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/java/com/zulip/android/networking/response/UploadResponse.java
+++ b/app/src/main/java/com/zulip/android/networking/response/UploadResponse.java
@@ -1,0 +1,13 @@
+package com.zulip.android.networking.response;
+
+import com.google.gson.annotations.SerializedName;
+
+public class UploadResponse {
+
+    @SerializedName("uri")
+    private String mUri;
+
+    public String getUri() {
+        return mUri;
+    }
+}

--- a/app/src/main/java/com/zulip/android/service/ZulipServices.java
+++ b/app/src/main/java/com/zulip/android/service/ZulipServices.java
@@ -2,18 +2,22 @@ package com.zulip.android.service;
 
 import com.zulip.android.filters.NarrowFilter;
 import com.zulip.android.networking.response.GetMessagesResponse;
+import com.zulip.android.networking.response.UploadResponse;
 import com.zulip.android.networking.response.LoginResponse;
 import com.zulip.android.networking.response.UserConfigurationResponse;
 import com.zulip.android.networking.response.ZulipBackendResponse;
 import com.zulip.android.networking.response.events.GetEventResponse;
 
+import okhttp3.MultipartBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Field;
 import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
+import retrofit2.http.Multipart;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
+import retrofit2.http.Part;
 import retrofit2.http.Query;
 
 
@@ -52,4 +56,7 @@ public interface ZulipServices {
     @POST("v1/dev_fetch_api_key")
     Call<LoginResponse> loginDEV(@Field("username") String username);
 
+    @Multipart
+    @POST("v1/user_uploads")
+    Call<UploadResponse> upload(@Part MultipartBody.Part file);
 }

--- a/app/src/main/java/com/zulip/android/util/FilePathHelper.java
+++ b/app/src/main/java/com/zulip/android/util/FilePathHelper.java
@@ -1,0 +1,135 @@
+package com.zulip.android.util;
+
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+
+/**
+ * This class helps to find the actual file path from a given content Uri
+ */
+
+public class FilePathHelper {
+    public static String getPath(final Context context, final Uri uri)
+    {
+        final boolean isKitKatOrAbove = Build.VERSION.SDK_INT >=  Build.VERSION_CODES.KITKAT;
+
+        // DocumentProvider
+        if (isKitKatOrAbove && DocumentsContract.isDocumentUri(context, uri)) {
+            // ExternalStorageProvider
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                }
+
+            }
+            // DownloadsProvider
+            else if (isDownloadsDocument(uri)) {
+
+                final String id = DocumentsContract.getDocumentId(uri);
+                final Uri contentUri = ContentUris.withAppendedId(
+                        Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+
+                return getDataColumn(context, contentUri, null, null);
+            }
+            // MediaProvider
+            else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[] {
+                        split[1]
+                };
+
+                return getDataColumn(context, contentUri, selection, selectionArgs);
+            }
+        }
+        // MediaStore (and general)
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+            return getDataColumn(context, uri, null, null);
+        }
+        // File
+        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the value of the data column for this Uri. This is useful for
+     * MediaStore Uris, and other file-based ContentProviders.
+     *
+     * @param context The context.
+     * @param uri The Uri to query.
+     * @param selection (Optional) Filter used in the query.
+     * @param selectionArgs (Optional) Selection arguments used in the query.
+     * @return The value of the _data column, which is typically a file path.
+     */
+    private static String getDataColumn(Context context, Uri uri, String selection,
+                                       String[] selectionArgs) {
+
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int column_index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(column_index);
+            }
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
+    }
+
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is ExternalStorageProvider.
+     */
+    private static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is DownloadsProvider.
+     */
+    private static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    /**
+     * @param uri The Uri to check.
+     * @return Whether the Uri authority is MediaProvider.
+     */
+    private static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+}

--- a/app/src/main/java/com/zulip/android/util/UrlHelper.java
+++ b/app/src/main/java/com/zulip/android/util/UrlHelper.java
@@ -6,7 +6,12 @@ public class UrlHelper {
 
     public static String addHost(String url) {
         if (!url.startsWith("http")) {
-            url = ZulipApp.get().getServerHostUri() + url;
+            String hostUrl = ZulipApp.get().getServerHostUri();
+            if (hostUrl.endsWith("/")) {
+                url = hostUrl.substring(0, hostUrl.length() - 1) + url;
+            } else {
+                url = hostUrl + url;
+            }
         }
 
        return url;

--- a/app/src/main/res/layout/chatbox.xml
+++ b/app/src/main/res/layout/chatbox.xml
@@ -81,6 +81,7 @@
             android:layout_height="15dp" />
 
         <TextView
+            android:id="@+id/sending_message"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingLeft="8dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,4 +89,8 @@
     <string name="no_topic_in_message">(no topic)</string>
     <string name="message_copied">Message Copied</string>
     <string name="login_failed">Unable to login</string>
+    <string name="uploading_message">Uploading</string>
+    <string name="cannot_upload_image">Cannot Upload Image</string>
+    <string name="cannot_find_image">Could not find the image</string>
+    <string name="failed_to_upload">Failed to upload</string>
 </resources>


### PR DESCRIPTION
This pr address #133 .
For now, I have added the functionality to share images, I will now work on sharing any type of files.
After sharing an image, the `ZulipActivity` starts and a `spinner` is shown during the upload. After uploading, the link of the image on server is added to the `messageEt` textView of `composeBox`.

**During upload**
![screenshot_20161017-115042](https://cloud.githubusercontent.com/assets/14239866/19427371/456bbb42-9461-11e6-988d-4d039aec5405.png)

**After upload is finished**
![screenshot_20161017-115046](https://cloud.githubusercontent.com/assets/14239866/19427374/473305a2-9461-11e6-8e1b-103657ceb532.png)
