### PR TITLE
Fixes #153: Show in-app new messages notifications snackbar

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -541,5 +541,8 @@ public class MessageListFragment extends Fragment implements MessageListener {
             loadMessageId(app.getMaxMessageId());
         }
     }
-
+    public boolean scrolledToLastMessage() {
+        Object object = adapter.getItem(linearLayoutManager.findLastVisibleItemPosition());
+        return object instanceof Message && (((Message) object).getId() >= app.getMaxMessageId() - 2);
+    }
 }

--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -549,6 +549,15 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
         return items.indexOf(message);
     }
 
+    public int getItemIndex(int id) {
+        for (int i = 0; i < items.size(); i++) {
+            if (items.get(i) instanceof Message && ((Message) items.get(i)).getId() == id) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     public Object getItem(int position) {
         return items.get(position);
     }

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -2054,7 +2054,8 @@ public class ZulipActivity extends BaseActivity implements
         if (narrowedList != null) {
             narrowedList.onNewMessages(messages);
         }
-        showSnackbarNotification(messages); //Show notification
+        if (!currentList.scrolledToLastMessage())
+            showSnackbarNotification(messages); //Show notification
     }
 
     Snackbar snackbar;

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -5,10 +5,8 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.Callable;
 import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
 
 import android.animation.Animator;
 import android.annotation.SuppressLint;
@@ -58,6 +56,7 @@ import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -168,6 +167,8 @@ public class ZulipActivity extends BaseActivity implements
     private AsyncGetEvents event_poll;
     private Handler statusUpdateHandler;
     private Runnable statusUpdateRunnable;
+
+    private int mToolbarHeightInPx;
     private MessageListFragment narrowedList;
     private MessageListFragment homeList;
     private AutoCompleteTextView streamActv;
@@ -2057,14 +2058,17 @@ public class ZulipActivity extends BaseActivity implements
     }
 
     Snackbar snackbar;
-
+    CoordinatorLayout.LayoutParams snackBarParams;
     private void setupSnackBar() {
         final CoordinatorLayout coordinatorLayout = (CoordinatorLayout) findViewById(R.id.coordinatorLayout);
         snackbar = Snackbar.make(coordinatorLayout, "", Snackbar.LENGTH_LONG);
         View v = snackbar.getView();
-        CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) v.getLayoutParams();
-        params.gravity = Gravity.TOP;
-        v.setLayoutParams(params);
+        snackBarParams = (CoordinatorLayout.LayoutParams) v.getLayoutParams();
+        snackBarParams.gravity = Gravity.TOP;
+        v.setLayoutParams(snackBarParams);
+        TypedValue tv = new TypedValue();
+        if (getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true))
+            mToolbarHeightInPx = TypedValue.complexToDimensionPixelSize(tv.data, getResources().getDisplayMetrics());
     }
 
     NarrowFilter narrowFilter;
@@ -2111,6 +2115,11 @@ public class ZulipActivity extends BaseActivity implements
                     doNarrow(narrowFilter);
                 }
             });
+        }
+        if (appBarLayout.getVisibility() == View.GONE) {
+            snackBarParams.setMargins(0, 0, 0, 0);
+        } else {
+            snackBarParams.setMargins(0, mToolbarHeightInPx, 0, 0);
         }
         snackbar.show();
     }

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -9,6 +9,7 @@
     <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:id="@+id/coordinatorLayout"
         android:fitsSystemWindows="true">
 
         <FrameLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,4 +118,15 @@
     <string name="enter_date">Enter Date</string>
     <string name="message_not_subscribed">Not subscribed to</string>
     <string name="keyword_stream">stream</string>
+    <plurals name="new_message" formatted="false">
+        <item quantity="one">%1$d new message %2$s</item>
+        <item quantity="other">%1$d new messages %2$s</item>
+    </plurals>
+    <string name="SHOW">SHOW</string>
+    <string name="notify_stream" formatted="false">" in %1$s/%2$s"</string>
+    <string name="notify_private" formatted="false">from %1$s</string>
+    <plurals name="new_message_mul_sender">
+        <item quantity="one">%d new message</item>
+        <item quantity="other">%d new messages</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Shows a snackbar in the top, snackbar message text changes according to private/stream messages and also changes text if messages from multiples topics/private messages recieved! 

<img src="https://cloud.githubusercontent.com/assets/12700799/19442073/ad1affde-94a5-11e6-89d8-2a0053b0a378.png" width="49%" />
<img src="https://cloud.githubusercontent.com/assets/12700799/19442072/ac8d2bb4-94a5-11e6-917b-e7a302f647eb.png" width="49%" />
