### PR TITLE
Visual fix: message spacing

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -48,7 +48,6 @@ import java.util.List;
  * initiated and called by {@link ZulipActivity}
  */
 public class MessageListFragment extends Fragment implements MessageListener {
-    private static final int PIXEL_OFFSET_MESSAGE_HEADERS = 24;
     private LinearLayoutManager linearLayoutManager;
     private MutedTopics mMutedTopics;
 
@@ -154,7 +153,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
         linearLayoutManager = new LinearLayoutManager(getContext());
         recyclerView.setLayoutManager(linearLayoutManager);
         adapter = new RecyclerMessageAdapter(messageList, getActivity(), (filter != null));
-        recyclerView.addItemDecoration(new HeaderSpaceItemDecoration(PIXEL_OFFSET_MESSAGE_HEADERS, getContext()));
+        recyclerView.addItemDecoration(new HeaderSpaceItemDecoration(getContext()));
         recyclerView.setAdapter(adapter);
         registerForContextMenu(recyclerView);
         recyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {

--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -542,11 +542,6 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
         notifyDataSetChanged();
     }
 
-    public void remove(Message msg) {
-        items.remove(msg);
-        notifyDataSetChanged();
-    }
-
     public int getItemIndex(Message message) {
         return items.indexOf(message);
     }

--- a/app/src/main/java/com/zulip/android/viewholders/HeaderSpaceItemDecoration.java
+++ b/app/src/main/java/com/zulip/android/viewholders/HeaderSpaceItemDecoration.java
@@ -14,12 +14,9 @@ import com.zulip.android.activities.RecyclerMessageAdapter;
  */
 public class HeaderSpaceItemDecoration extends RecyclerView.ItemDecoration {
 
-    private final int verticalMargin;
-
     private int toolbarHeight;
 
-    public HeaderSpaceItemDecoration(int verticalMargin, Context context) {
-        this.verticalMargin = verticalMargin;
+    public HeaderSpaceItemDecoration(Context context) {
         TypedValue tv = new TypedValue();
         if (context.getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
             toolbarHeight = TypedValue.complexToDimensionPixelSize(tv.data, context.getResources().getDisplayMetrics());
@@ -33,11 +30,9 @@ public class HeaderSpaceItemDecoration extends RecyclerView.ItemDecoration {
         int position = parent.getChildAdapterPosition(view);
         int size = parent.getAdapter().getItemCount();
         int viewType = parent.getAdapter().getItemViewType(position);
-        if (viewType == RecyclerMessageAdapter.VIEWTYPE_MESSAGE_HEADER && position != 0) {
-            outRect.top = verticalMargin;
-        } else if (viewType == RecyclerMessageAdapter.VIEWTYPE_HEADER) {
+        if (viewType == RecyclerMessageAdapter.VIEWTYPE_HEADER) {
             outRect.top = toolbarHeight;
         }
-        outRect.bottom = (position == size - 2) ? verticalMargin : 0;
+        outRect.bottom = 0;
     }
 }

--- a/app/src/main/res/layout/message_header.xml
+++ b/app/src/main/res/layout/message_header.xml
@@ -2,6 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginTop="12dp"
     android:background="@color/messageHeaderBackground">
 
     <TextView

--- a/app/src/main/res/layout/message_tile.xml
+++ b/app/src/main/res/layout/message_tile.xml
@@ -29,8 +29,8 @@
             tools:background="#FFF">
 
             <TextView
-                android:paddingTop="10dp"
                 android:id="@+id/senderName"
+                android:paddingTop="10dp"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"


### PR DESCRIPTION
When a new message comes in, even if it's under the same stream as the above message, extra spacing gets added between messages.  Same for the Loading Messages... notification at start.

This PR removes the extra space and cleans up an unused method.