### PR TITLE
Fix bug#227

### DIFF
--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -187,7 +187,7 @@ public class ZulipApp extends Application {
     }
 
     public ZulipServices getZulipServices() {
-        if(zulipServices == null) {
+        if (zulipServices == null) {
             HttpLoggingInterceptor logging = new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY);
             zulipServices = new Retrofit.Builder()
                     .client(new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS)
@@ -200,6 +200,10 @@ public class ZulipApp extends Application {
                     .create(ZulipServices.class);
         }
         return zulipServices;
+    }
+
+    public void setZulipServices(ZulipServices zulipServices) {
+        this.zulipServices = zulipServices;
     }
 
     public Gson getGson() {

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -151,6 +151,10 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
 
     private void checkForError() {
         String serverURL = serverIn.getText().toString();
+
+        // trim leading or trailing white spaces in Url
+        serverURL = serverURL.trim();
+
         int errorMessage = R.string.invalid_server_domain;
         String httpScheme = (BuildConfig.DEBUG) ? "http" : "https";
 
@@ -184,6 +188,11 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
     }
 
     private void showBackends(String httpScheme, String serverURL) {
+        // if server url does not end with "/", then append it
+        if (!serverURL.endsWith("/")) {
+            serverURL = serverURL + "/";
+        }
+
         Uri serverUri = Uri.parse(serverURL);
 
         serverUri = serverUri.buildUpon().scheme(httpScheme).build();
@@ -197,6 +206,9 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
         mServerEditText.setText(serverUri.toString());
         mServerEditText.setEnabled(false);
         ((ZulipApp) getApplication()).setServerURL(serverUri.toString());
+
+        // create new zulipServices object every time by setting it to null
+        getApp().setZulipServices(null);
 
         getServices()
                 .getAuthBackends()

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -197,14 +197,17 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
 
         serverUri = serverUri.buildUpon().scheme(httpScheme).build();
 
-        // if does not begin with "api.zulip.com" and if the path is empty, use "/api" as first segment in the path
-        List<String> paths = serverUri.getPathSegments();
-        if (!serverUri.getHost().startsWith("api.") && paths.isEmpty()) {
-            serverUri = serverUri.buildUpon().appendEncodedPath("api/").build();
-        }
+        // display server url with http scheme used
         serverIn.setText(serverUri.toString());
         mServerEditText.setText(serverUri.toString());
         mServerEditText.setEnabled(false);
+
+        // if server url does not end with "api/" or if the path is empty, use "/api" as last segment in the path
+        List<String> paths = serverUri.getPathSegments();
+        if (paths.isEmpty() || !paths.get(paths.size() - 1).equals("api")) {
+            serverUri = serverUri.buildUpon().appendEncodedPath("api/").build();
+        }
+
         ((ZulipApp) getApplication()).setServerURL(serverUri.toString());
 
         // create new zulipServices object every time by setting it to null


### PR DESCRIPTION
This pr addresses #227 
The server url first entered (when the app is started) was being used every time, regardless of what the user typed in next. Therefore, I added a new function `setZulipServices()` in `ZulipApp.java` and used it to set `zulipServices` to `null` before calling `getServices()` in `LoginActivity`. This will cause new `zulipServices` object creation **only during login**.
I have also hidden `/api` from the user and removed any leading/trailing spaces in `serverUrl` entered by the user.