### PR TITLE
Fixes #233

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -497,8 +497,9 @@ public class ZulipActivity extends BaseActivity implements
                 int index = cursor.getColumnIndex(Emoji.NAME_FIELD);
                 String name = cursor.getString(index);
                 String currText = messageEt.getText().toString();
-                int last = (cursor.getColumnIndex(Emoji.NAME_FIELD) == 6) ? currText.lastIndexOf("@") : currText.lastIndexOf(":");
-                return TextUtils.substring(currText, 0, last) + ((cursor.getColumnIndex(Emoji.NAME_FIELD) == 6) ? "@**" + name + "**" : ":" + name.replace(".png", "") + ":");
+                int numberOfColumns = cursor.getColumnCount();
+                int last = (numberOfColumns > 2) ? currText.lastIndexOf("@") : currText.lastIndexOf(":");
+                return TextUtils.substring(currText, 0, last) + ((numberOfColumns > 2) ? "@**" + name + "**" : ":" + name.replace(".png", "") + ":");
             }
         });
         combinedAdapter.setFilterQueryProvider(new FilterQueryProvider() {


### PR DESCRIPTION
This pr addresses #233 
The existing code relies on column index to distinguish between emoji or person cursor in `combinedAdapter`. As a good database practice, _we should never rely on the defined order of fields in any database_
Hence, I have used total number of columns to see which cursor is being used.
Somehow, this error occurs only for devices running on android versions 5.0 or less. I have test my changes on versions 4.x, 5.x and 6.x