### PR TITLE
Double back press to exit implemented

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="title_activity_legal">Legal</string>
     <string name="streams_open">Open stream sidebar</string>
     <string name="streams_close">Close stream sidebar</string>
+    <string name="press_again_to_exit">Press again to exit</string>
 
     <!-- Used on the indicator when loading messages -->
     <string name="loading_messages">Loading messages</string>


### PR DESCRIPTION
PR Addresses [#236](https://github.com/zulip/zulip-android/issues/236)

Now if the user presses back button to exit, a toast message appears which prompts the user to press back button again to exit.

@kunall17 @timabbott  Review it.