### PR TITLE
Fixes the expandableListView in the streams drawer

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ExpandableStreamDrawerAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/ExpandableStreamDrawerAdapter.java
@@ -32,9 +32,9 @@ public class ExpandableStreamDrawerAdapter extends SimpleCursorTreeAdapter {
     public Cursor getChildrenCursor(Cursor groupCursor) {
         int pointer = zulipApp.getPointer();
         List<String[]> results = new ArrayList<>();
-        try {results = ZulipApp.get().getDao(Message.class).queryRaw("SELECT DISTINCT subject, count(case when messages.id > " + pointer + " or messages." + Message.MESSAGE_READ_FIELD + " = 0 then 1 end) as unreadcount FROM messages " +
-                    "JOIN streams ON streams.id=messages.stream " +
-                    "WHERE streams.id=" + groupCursor.getInt(0) + " group by subject").getResults();
+        try {results = ZulipApp.get().getDao(Message.class).queryRaw("SELECT DISTINCT subject, count(case when messages.id > " + pointer + " or messages." + Message.MESSAGE_READ_FIELD + " = 0 or messages." + Message.MESSAGE_READ_FIELD + " = NULL then 1 end) as unreadcount FROM messages " +
+                    "JOIN streams ON streams.name=messages.recipients " +
+                    "WHERE streams.name like '" + groupCursor.getString(1) + "' group by subject").getResults();
         } catch (SQLException e) {
             ZLog.logException(e);
         }

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -919,12 +919,12 @@ public class ZulipActivity extends BaseActivity implements
                     case R.id.unread_group:
                         TextView unreadGroupTextView = (TextView) view;
                         final String unreadGroupCount = cursor.getString(columnIndex);
-//                        if (unreadGroupCount.equals("0")) {
-//                            unreadGroupTextView.setVisibility(View.GONE);
-//                        } else {
-//                            unreadGroupTextView.setText(unreadGroupCount);
-//                            unreadGroupTextView.setVisibility(View.VISIBLE);
-//                        }
+                        if (unreadGroupCount.equals("0")) {
+                            unreadGroupTextView.setVisibility(View.GONE);
+                        } else {
+                            unreadGroupTextView.setText(unreadGroupCount);
+                            unreadGroupTextView.setVisibility(View.VISIBLE);
+                        }
                         return true;
                     case R.id.unread_child:
                         TextView unreadChildTextView = (TextView) view;

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -831,7 +831,7 @@ public class ZulipActivity extends BaseActivity implements
             int pointer = app.getPointer();
             return ((AndroidDatabaseResults) app.getDao(Stream.class).queryRaw("SELECT s.id as _id,  s.name, s.color," +
                     " count(case when m.id > " + pointer + " or m." + Message.MESSAGE_READ_FIELD + " = 0 then 1 end) as " + ExpandableStreamDrawerAdapter.UNREAD_TABLE_NAME
-                    + " FROM streams as s LEFT JOIN messages as m ON s.id=m.stream group by s.name order by s.name COLLATE NOCASE").closeableIterator().getRawResults()).getRawCursor();
+                    + " FROM streams as s LEFT JOIN messages as m ON s.name=m.recipients group by s.name order by s.name COLLATE NOCASE").closeableIterator().getRawResults()).getRawCursor();
         }
     };
 

--- a/app/src/main/java/com/zulip/android/models/Message.java
+++ b/app/src/main/java/com/zulip/android/models/Message.java
@@ -130,7 +130,9 @@ public class Message {
 
     @DatabaseField(foreign = true, columnName = STREAM_FIELD, foreignAutoRefresh = true)
     private Stream stream;
-    @DatabaseField(columnName = MESSAGE_READ_FIELD)
+
+    @NonNull
+    @DatabaseField(columnName = MESSAGE_READ_FIELD, defaultValue = "0")
     private Boolean messageRead;
 
     @DatabaseField(columnDefinition = MESSAGE_EDITED)


### PR DESCRIPTION
This was because in the messages table stream column and the read column have null values which should not be the case, I have uploaded the database of the android app which is dumped after the first login to the app, if any one wants to tinker with the queries (Maybe the SQL queries can be made better)
[databases.zip](https://github.com/zulip/zulip-android/files/661897/databases.zip)

Previously the queries were dependent on the id's now they are being compared by names!

2e4ce93 is basically removing 0fea6fbc525390f9a50ab476b7126f9203fb3dee commit, not sure though if this is the best method to do this! 

<img src="https://cloud.githubusercontent.com/assets/12700799/21325660/6cbfd214-c64d-11e6-8ee5-f9c46abbf87d.png" width="49%" />
