### PR TITLE
Use SelectArgs to compare strings.

### DIFF
--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -24,6 +24,7 @@ import com.j256.ormlite.dao.ObjectCache;
 import com.j256.ormlite.dao.ReferenceObjectCache;
 import com.j256.ormlite.dao.RuntimeExceptionDao;
 import com.j256.ormlite.misc.TransactionManager;
+import com.j256.ormlite.stmt.SelectArg;
 import com.zulip.android.activities.ZulipActivity;
 import com.zulip.android.database.DatabaseHelper;
 import com.zulip.android.models.Emoji;
@@ -274,7 +275,9 @@ public class ZulipApp extends Application {
                             Person currentPerson = res.getRealmUsers().get(i);
                             Person foundPerson = null;
                             try {
-                                foundPerson = personDao.queryBuilder().where().eq(Person.EMAIL_FIELD, currentPerson.getEmail()).queryForFirst();
+                                foundPerson = personDao.queryBuilder().where().eq(Person.EMAIL_FIELD,
+                                        new SelectArg(Person.EMAIL_FIELD, currentPerson.getEmail()))
+                                        .queryForFirst();
                                 if(foundPerson != null) {
                                     currentPerson.setId(foundPerson.getId());
                                 }


### PR DESCRIPTION
This pr solves non-fatal issue 5 in the release build.
Here's a stacktrace for the error
```
E/SQLiteLog: (1) near "callahanb": syntax error
E/Error: oops
         java.sql.SQLException: Problems executing Android query: SELECT * FROM `people` WHERE `email` = 'xyz'@example.com'  LIMIT 1
             at com.j256.ormlite.misc.SqlExceptionUtil.create(SqlExceptionUtil.java:27)
             at com.j256.ormlite.android.AndroidCompiledStatement.getCursor(AndroidCompiledStatement.java:197)
             at com.j256.ormlite.android.AndroidCompiledStatement.runQuery(AndroidCompiledStatement.java:72)
             at com.j256.ormlite.stmt.StatementExecutor.queryForFirst(StatementExecutor.java:106)
             at com.j256.ormlite.dao.BaseDaoImpl.queryForFirst(BaseDaoImpl.java:239)
             at com.j256.ormlite.stmt.QueryBuilder.queryForFirst(QueryBuilder.java:380)
             at com.j256.ormlite.stmt.Where.queryForFirst(Where.java:494)
             at com.zulip.android.ZulipApp$6.read(ZulipApp.java:277)
             at com.zulip.android.ZulipApp$6.read(ZulipApp.java:260)
             at retrofit2.converter.gson.GsonResponseBodyConverter.convert(GsonResponseBodyConverter.java:37)
             at retrofit2.converter.gson.GsonResponseBodyConverter.convert(GsonResponseBodyConverter.java:25)
             at retrofit2.ServiceMethod.toResponse(ServiceMethod.java:117)
             at retrofit2.OkHttpCall.parseResponse(OkHttpCall.java:211)
             at retrofit2.OkHttpCall.execute(OkHttpCall.java:174)
             at retrofit2.ExecutorCallAdapterFactory$ExecutorCallbackCall.execute(ExecutorCallAdapterFactory.java:89)
             at com.zulip.android.networking.AsyncGetEvents.register(AsyncGetEvents.java:109)
             at com.zulip.android.networking.AsyncGetEvents.run(AsyncGetEvents.java:204)
          Caused by: android.database.sqlite.SQLiteException: near "callahanb": syntax error (code 1): , while compiling: SELECT * FROM `people` WHERE `email` = 'xyz'@example.com'  LIMIT 1
         #################################################################
         Error Code : 1 (SQLITE_ERROR)
         Caused By : SQL(query) error or missing database.
         	(near "callahanb": syntax error (code 1): , while compiling: SELECT * FROM `people` WHERE `email` = 'xyz'@example.com'  LIMIT 1)
         #################################################################
             at android.database.sqlite.SQLiteConnection.nativePrepareStatement(Native Method)
             at android.database.sqlite.SQLiteConnection.acquirePreparedStatement(SQLiteConnection.java:1058)
             at android.database.sqlite.SQLiteConnection.prepare(SQLiteConnection.java:623)
             at android.database.sqlite.SQLiteSession.prepare(SQLiteSession.java:588)
             at android.database.sqlite.SQLiteProgram.<init>(SQLiteProgram.java:59)
             at android.database.sqlite.SQLiteQuery.<init>(SQLiteQuery.java:37)
             at android.database.sqlite.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:44)
             at android.database.sqlite.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:1471)
             at android.database.sqlite.SQLiteDatabase.rawQuery(SQLiteDatabase.java:1410)
             at com.j256.ormlite.android.compat.JellyBeanApiCompatibility.rawQuery(JellyBeanApiCompatibility.java:21)
             at com.j256.ormlite.android.AndroidCompiledStatement.getCursor(AndroidCompiledStatement.java:193)
             	... 15 more
```
When comparing strings for equality, we should use `selectArgs()`.