### PR TITLE
Use createOrUpdate only when id exists

### DIFF
--- a/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
@@ -167,8 +167,16 @@ public class AsyncGetEvents extends Thread {
                         Person person = people.get(i);
                         person.setActive(true);
                         try {
-                            personDao.createOrUpdate(person);
-                        } catch (Exception e) {
+                            // Ormlite uses a query-by-id to see if it needs to update
+                            // or create a new row using createOrUpdate()
+                            // Hence, the object passed should always have an id.
+                            if (Person.getByEmail(app, person.getEmail()) == null) {
+                                personDao.create(person);
+                            } else {
+                                personDao.update(person);
+                            }
+                        }
+                        catch(Exception e) {
                             ZLog.logException(e);
                         }
                     }


### PR DESCRIPTION
This pr addresses non-fatal issue 49 in release build.
According to ormlite docs, `createOrUpdate` method uses id to find if a row exists in the table or not. But the user configuration response we receive is not deserialized into a person object with an id as it is supposed to be auto-generated. Hence we are getting this error
```
Non-fatal Exception: java.lang.RuntimeException: java.sql.SQLException: Unable to run insert stmt on object com.zulip.android.models.Person@55e51053: INSERT INTO `people` (`avatarUrl` ,`email` ,`isActive` ,`isBot` ,`name` ) VALUES (?,?,?,?,?)
       at com.j256.ormlite.dao.RuntimeExceptionDao.createOrUpdate(RuntimeExceptionDao.java:277)
       at com.zulip.android.networking.AsyncGetEvents$1.call(AsyncGetEvents.java:171)
       at com.zulip.android.networking.AsyncGetEvents$1.call(AsyncGetEvents.java:127)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:227)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:169)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:150)
       at com.zulip.android.networking.AsyncGetEvents.processRegister(AsyncGetEvents.java:126)
       at com.zulip.android.networking.AsyncGetEvents.register(AsyncGetEvents.java:118)
       at com.zulip.android.networking.AsyncGetEvents.run(AsyncGetEvents.java:204)
Caused by java.sql.SQLException: Unable to run insert stmt on object com.zulip.android.models.Person@55e51053: INSERT INTO `people` (`avatarUrl` ,`email` ,`isActive` ,`isBot` ,`name` ) VALUES (?,?,?,?,?)
       at com.j256.ormlite.misc.SqlExceptionUtil.create(SqlExceptionUtil.java:25)
       at com.j256.ormlite.stmt.mapped.MappedCreate.insert(MappedCreate.java:137)
       at com.j256.ormlite.stmt.StatementExecutor.create(StatementExecutor.java:458)
       at com.j256.ormlite.dao.BaseDaoImpl.create(BaseDaoImpl.java:328)
       at com.j256.ormlite.dao.BaseDaoImpl.createOrUpdate(BaseDaoImpl.java:387)
       at com.j256.ormlite.dao.RuntimeExceptionDao.createOrUpdate(RuntimeExceptionDao.java:274)
       at com.zulip.android.networking.AsyncGetEvents$1.call(AsyncGetEvents.java:171)
       at com.zulip.android.networking.AsyncGetEvents$1.call(AsyncGetEvents.java:127)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:227)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:169)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:150)
       at com.zulip.android.networking.AsyncGetEvents.processRegister(AsyncGetEvents.java:126)
       at com.zulip.android.networking.AsyncGetEvents.register(AsyncGetEvents.java:118)
       at com.zulip.android.networking.AsyncGetEvents.run(AsyncGetEvents.java:204)
Caused by java.sql.SQLException: inserting to database failed: INSERT INTO `people` (`avatarUrl` ,`email` ,`isActive` ,`isBot` ,`name` ) VALUES (?,?,?,?,?)
       at com.j256.ormlite.misc.SqlExceptionUtil.create(SqlExceptionUtil.java:27)
       at com.j256.ormlite.android.AndroidDatabaseConnection.insert(AndroidDatabaseConnection.java:180)
       at com.j256.ormlite.stmt.mapped.MappedCreate.insert(MappedCreate.java:91)
       at com.j256.ormlite.stmt.StatementExecutor.create(StatementExecutor.java:458)
       at com.j256.ormlite.dao.BaseDaoImpl.create(BaseDaoImpl.java:328)
       at com.j256.ormlite.dao.BaseDaoImpl.createOrUpdate(BaseDaoImpl.java:387)
       at com.j256.ormlite.dao.RuntimeExceptionDao.createOrUpdate(RuntimeExceptionDao.java:274)
       at com.zulip.android.networking.AsyncGetEvents$1.call(AsyncGetEvents.java:171)
       at com.zulip.android.networking.AsyncGetEvents$1.call(AsyncGetEvents.java:127)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:227)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:169)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:150)
       at com.zulip.android.networking.AsyncGetEvents.processRegister(AsyncGetEvents.java:126)
       at com.zulip.android.networking.AsyncGetEvents.register(AsyncGetEvents.java:118)
       at com.zulip.android.networking.AsyncGetEvents.run(AsyncGetEvents.java:204)
Caused by android.database.sqlite.SQLiteConstraintException: UNIQUE constraint failed: people.email (code 2067)
       at android.database.sqlite.SQLiteConnection.nativeExecuteForLastInsertedRowId(SQLiteConnection.java)
       at android.database.sqlite.SQLiteConnection.executeForLastInsertedRowId(SQLiteConnection.java:786)
       at android.database.sqlite.SQLiteSession.executeForLastInsertedRowId(SQLiteSession.java:788)
       at android.database.sqlite.SQLiteStatement.executeInsert(SQLiteStatement.java:86)
       at com.j256.ormlite.android.AndroidDatabaseConnection.insert(AndroidDatabaseConnection.java:168)
       at com.j256.ormlite.stmt.mapped.MappedCreate.insert(MappedCreate.java:91)
       at com.j256.ormlite.stmt.StatementExecutor.create(StatementExecutor.java:458)
       at com.j256.ormlite.dao.BaseDaoImpl.create(BaseDaoImpl.java:328)
       at com.j256.ormlite.dao.BaseDaoImpl.createOrUpdate(BaseDaoImpl.java:387)
       at com.j256.ormlite.dao.RuntimeExceptionDao.createOrUpdate(RuntimeExceptionDao.java:274)
       at com.zulip.android.networking.AsyncGetEvents$1.call(AsyncGetEvents.java:171)
       at com.zulip.android.networking.AsyncGetEvents$1.call(AsyncGetEvents.java:127)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:227)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:169)
       at com.j256.ormlite.misc.TransactionManager.callInTransaction(TransactionManager.java:150)
       at com.zulip.android.networking.AsyncGetEvents.processRegister(AsyncGetEvents.java:126)
       at com.zulip.android.networking.AsyncGetEvents.register(AsyncGetEvents.java:118)
       at com.zulip.android.networking.AsyncGetEvents.run(AsyncGetEvents.java:204)
```