### PR TITLE
Fix null streams

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ExpandableStreamDrawerAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/ExpandableStreamDrawerAdapter.java
@@ -7,6 +7,7 @@ import android.widget.SimpleCursorTreeAdapter;
 
 import com.zulip.android.ZulipApp;
 import com.zulip.android.models.Message;
+import com.zulip.android.models.Stream;
 import com.zulip.android.util.ZLog;
 
 import java.sql.SQLException;
@@ -35,7 +36,7 @@ public class ExpandableStreamDrawerAdapter extends SimpleCursorTreeAdapter {
         try {
             results = ZulipApp.get().getDao(Message.class).queryRaw("SELECT DISTINCT subject, count(case when messages.id > " + pointer + " or messages." + Message.MESSAGE_READ_FIELD + " = 0 then 1 end) as unreadcount FROM messages " +
                     "JOIN streams ON streams.id=messages.stream " +
-                    "WHERE streams.id=" + groupCursor.getInt(0) + " group by subject").getResults();
+                    "WHERE streams.id=" + groupCursor.getInt(0) + " and streams." + Stream.SUBSCRIBED_FIELD + " = " + "1 group by subject").getResults();
         } catch (SQLException e) {
             ZLog.logException(e);
         }

--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -443,8 +443,8 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                 } catch (SQLException e) {
                     ZLog.logException(e);
                 }
+                zulipApp.markMessageAsRead(message);
             }
-            zulipApp.markMessageAsRead(message);
         } catch (NullPointerException e) {
             Log.w("scrolling", "Could not find a location to scroll to!");
         }

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -1,13 +1,6 @@
 package com.zulip.android.activities;
 
 import android.Manifest;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.ArrayList;
-
 import android.animation.Animator;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
@@ -641,11 +634,12 @@ public class ZulipActivity extends BaseActivity implements
                         + " FROM streams as s LEFT JOIN messages as m ON s.id=m.stream ";
                 if (!etSearchStream.getText().toString().equals("") && !etSearchStream.getText().toString().isEmpty()) {
                     //append where clause
-                    query += " WHERE s.name LIKE '%" + etSearchStream.getText().toString() + "%'";
+                    query += " WHERE s.name LIKE '%" + etSearchStream.getText().toString() + "%'" + " and s." + Stream.SUBSCRIBED_FIELD + " = " + "1 ";
                     //set visibility of this image false
                     ivSearchStreamCancel.setVisibility(View.VISIBLE);
                 } else {
                     //set visibility of this image false
+                    query += " WHERE s." + Stream.SUBSCRIBED_FIELD + " = " + "1 ";
                     ivSearchStreamCancel.setVisibility(View.GONE);
                 }
                 //append group by

--- a/app/src/main/java/com/zulip/android/database/DatabaseHelper.java
+++ b/app/src/main/java/com/zulip/android/database/DatabaseHelper.java
@@ -30,7 +30,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
     private static final String DATABASE_NAME = "zulip-%s.db";
     // any time you make changes to your database objects, you may have to
     // increase the database version
-    private static final int DATABASE_VERSION = 6;
+    private static final int DATABASE_VERSION = 7;
 
     public DatabaseHelper(ZulipApp app, String email) {
         super(app, String.format(DATABASE_NAME, MD5Util.md5Hex(email)), null,

--- a/app/src/main/java/com/zulip/android/models/Message.java
+++ b/app/src/main/java/com/zulip/android/models/Message.java
@@ -235,6 +235,11 @@ public class Message {
                     for (Message m : messages) {
                         Person person = Person.getOrUpdate(app, m.getSenderEmail(), m.getSenderFullName(), m.getAvatarUrl());
                         m.setSender(person);
+                        Stream stream = null;
+                        if (m.getType() == MessageType.STREAM_MESSAGE) {
+                            stream = Stream.getByName(app, m.getRecipients());
+                        }
+                        m.setStream(stream);
                         messageDao.createOrUpdate(m);
                     }
                     return null;

--- a/app/src/main/java/com/zulip/android/models/Stream.java
+++ b/app/src/main/java/com/zulip/android/models/Stream.java
@@ -39,7 +39,7 @@ public class Stream {
     private String description;
 
     @SerializedName("subscribers")
-    private List<Integer> subscribers;
+    private List<String> subscribers;
 
     @SerializedName("pin_to_top")
     private boolean pinToTop;
@@ -211,4 +211,12 @@ public class Stream {
         return null;
     }
 
+    public void setFetchColor(String fetchedColor) {
+        this.fetchedColor = fetchedColor;
+        getParsedColor();
+    }
+
+    public void setInHomeView(boolean inHomeView) {
+        this.inHomeView = inHomeView;
+    }
 }

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
@@ -134,7 +134,7 @@ public class AsyncGetEvents extends Thread {
 
                     RuntimeExceptionDao<Stream, Object> streamDao = app
                             .getDao(Stream.class);
-                    Log.i("stream", "" + subscriptions.size() + " streams");
+                    Log.i("stream", "" + subscriptions.size() + " subscribed streams");
 
                     // Mark all existing subscriptions as not subscribed
                     streamDao.updateBuilder().updateColumnValue(
@@ -150,6 +150,19 @@ public class AsyncGetEvents extends Thread {
                             ZLog.logException(e);
                         }
                     }
+
+                    // get unsubscribed streams
+                    List<Stream> unsubscribed = response.getUnsubscribed();
+                    for (Stream stream : unsubscribed) {
+                        stream.getParsedColor();
+                        stream.setSubscribed(false);
+                        try {
+                            streamDao.createOrUpdate(stream);
+                        } catch (Exception e) {
+                            ZLog.logException(e);
+                        }
+                    }
+
                     //MUST UPDATE AFTER SUBSCRIPTIONS ARE STORED IN DB
                     mMutedTopics.addToMutedTopics(response.getMutedTopics());
 

--- a/app/src/main/java/com/zulip/android/networking/response/UserConfigurationResponse.java
+++ b/app/src/main/java/com/zulip/android/networking/response/UserConfigurationResponse.java
@@ -97,7 +97,7 @@ public class UserConfigurationResponse {
     private List<Stream> realmDefaultStreams;
 
     @SerializedName("unsubscribed")
-    private List<?> unsubscribed;
+    private List<Stream> unsubscribed;
 
     @SerializedName("subscriptions")
     private List<Stream> subscriptions;
@@ -216,7 +216,7 @@ public class UserConfigurationResponse {
         return realmDefaultStreams;
     }
 
-    public List<?> getUnsubscribed() {
+    public List<Stream> getUnsubscribed() {
         return unsubscribed;
     }
 

--- a/app/src/main/java/com/zulip/android/networking/response/events/EventsBranch.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/EventsBranch.java
@@ -23,7 +23,8 @@ public class EventsBranch {
 
     public enum BranchType {
         MESSAGE(MessageWrapper.class, "message"),
-        PRESENCE(PresenceWrapper.class, "presence");
+        PRESENCE(PresenceWrapper.class, "presence"),
+        SUBSCRIPTIONS(SubscriptionWrapper.class, "subscription");
 
         private final Class<? extends EventsBranch> klazz;
         private final String key;

--- a/app/src/main/java/com/zulip/android/networking/response/events/EventsBranch.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/EventsBranch.java
@@ -24,7 +24,8 @@ public class EventsBranch {
     public enum BranchType {
         MESSAGE(MessageWrapper.class, "message"),
         PRESENCE(PresenceWrapper.class, "presence"),
-        SUBSCRIPTIONS(SubscriptionWrapper.class, "subscription");
+        SUBSCRIPTIONS(SubscriptionWrapper.class, "subscription"),
+        MUTED_TOPICS(MutedTopicsWrapper.class, "muted_topics");
 
         private final Class<? extends EventsBranch> klazz;
         private final String key;

--- a/app/src/main/java/com/zulip/android/networking/response/events/GetEventResponse.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/GetEventResponse.java
@@ -74,6 +74,11 @@ public class GetEventResponse {
         this.result = result;
     }
 
+    /**
+     * TODO: add description
+     * @param branchType
+     * @return
+     */
     public List<EventsBranch> getEventsOfBranchType(EventsBranch.BranchType branchType) {
         List<EventsBranch> branches = this.getEvents();
 

--- a/app/src/main/java/com/zulip/android/networking/response/events/GetEventResponse.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/GetEventResponse.java
@@ -75,9 +75,11 @@ public class GetEventResponse {
     }
 
     /**
-     * TODO: add description
-     * @param branchType
-     * @return
+     * Function to get events of branch type {@param branchType} from {@link GetEventResponse#events}
+     * list.
+     *
+     * @param branchType {@link EventsBranch.BranchType}
+     * @return list of events of branch type {@param branchType}
      */
     public List<EventsBranch> getEventsOfBranchType(EventsBranch.BranchType branchType) {
         List<EventsBranch> branches = this.getEvents();

--- a/app/src/main/java/com/zulip/android/networking/response/events/GetEventResponse.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/GetEventResponse.java
@@ -74,5 +74,16 @@ public class GetEventResponse {
         this.result = result;
     }
 
+    public List<EventsBranch> getEventsOfBranchType(EventsBranch.BranchType branchType) {
+        List<EventsBranch> branches = this.getEvents();
 
+        List<EventsBranch> retVal = new ArrayList<>();
+        for (EventsBranch eventBranch : branches) {
+            if (eventBranch.getClass().equals(branchType.getKlazz())) {
+                retVal.add(eventBranch);
+            }
+        }
+
+        return retVal;
+    }
 }

--- a/app/src/main/java/com/zulip/android/networking/response/events/MessageWrapper.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/MessageWrapper.java
@@ -5,7 +5,19 @@ import com.zulip.android.models.Message;
 
 import java.util.List;
 
-
+/**
+ * This class is used to deserialize the message type event {@link EventsBranch.BranchType#MESSAGE}
+ *
+ * example : {"flags":[],"message":{"reactions":[],"recipient_id":38,
+ *      "sender_email":"error-bot@zulip.com","timestamp":1485172576,"display_recipient":"logs",
+ *      "sender_id":10,"sender_full_name":"Zulip Error Bot","sender_domain":"zulip.com",
+ *      "content":"<div class=\"codehilite\"><pre><span></span>10.0.3.1        POST    200  4.1s (db: 217ms/2q) /api/v1/users/me/presence (AARON@zulip.com via ZulipAndroid) (AARON@zulip.com)\n</pre></div>",
+ *      "stream_id":15,"gravatar_hash":"de425733f46e97dae34e4282037edd7e",
+ *      "avatar_url":"https://secure.gravatar.com/avatar/de425733f46e97dae34e4282037edd7e?d=identicon",
+ *      "client":"Internal","content_type":"text/html","subject_links":[],"is_mentioned":false,
+ *      "sender_short_name":"error-bot","type":"stream","id":1522,"subject":"localhost:9991: slow queries"},
+ *      "type":"message","id":8}
+ */
 public class MessageWrapper extends EventsBranch {
     @SerializedName("message")
     private Message message;

--- a/app/src/main/java/com/zulip/android/networking/response/events/MutedTopicsWrapper.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/MutedTopicsWrapper.java
@@ -1,0 +1,23 @@
+package com.zulip.android.networking.response.events;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * TODO: add description
+ * example : {"muted_topics":[["testing","(no topic)"]],"type":"muted_topics","id":42}
+ */
+
+public class MutedTopicsWrapper extends EventsBranch{
+    @SerializedName("muted_topics")
+    private List<List<String>> mutedTopics;
+
+    public List<List<String>> getMutedTopics() {
+        return this.mutedTopics;
+    }
+
+    public void setMutedTopics(List<List<String>> mutedTopics) {
+        this.mutedTopics = mutedTopics;
+    }
+}

--- a/app/src/main/java/com/zulip/android/networking/response/events/MutedTopicsWrapper.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/MutedTopicsWrapper.java
@@ -5,8 +5,11 @@ import com.google.gson.annotations.SerializedName;
 import java.util.List;
 
 /**
- * TODO: add description
- * example : {"muted_topics":[["testing","(no topic)"]],"type":"muted_topics","id":42}
+ * This class is used to deserialize muted_topic type event
+ * {@link EventsBranch.BranchType#MUTED_TOPICS}.
+ *
+ * example: {"muted_topics":[["devel","(no topic)"],["foraaron","(no topic)"],["announce","Streams"]],
+ *      "type":"muted_topics","id":20}
  */
 
 public class MutedTopicsWrapper extends EventsBranch{

--- a/app/src/main/java/com/zulip/android/networking/response/events/PresenceWrapper.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/PresenceWrapper.java
@@ -3,7 +3,12 @@ package com.zulip.android.networking.response.events;
 import com.google.gson.annotations.SerializedName;
 import com.zulip.android.models.Presence;
 
-
+/**
+ * This class is used to deserialize the presence type event {@link EventsBranch.BranchType#PRESENCE}
+ *
+ * example : {"id":0,"server_timestamp":1485171896.1950330734,"type":"presence","email":"example@gmail.com",
+ *      "presence":{"ZulipAndroid":{"status":"active","timestamp":1485171896,"client":"ZulipAndroid","pushable":null}}}
+ */
 public class PresenceWrapper extends EventsBranch {
 
     @SerializedName("server_timestamp")

--- a/app/src/main/java/com/zulip/android/networking/response/events/SubscriptionWrapper.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/SubscriptionWrapper.java
@@ -7,7 +7,28 @@ import com.zulip.android.models.Stream;
 import java.util.List;
 
 /**
- * TODO: add description
+ * This class is used to deserialize the subscription type events {@link EventsBranch.BranchType#SUBSCRIPTIONS}.
+ *
+ * example : Add operation  {"subscriptions":[{"desktop_notifications":true,"description":"For sales discussion",
+ *      "color":"#f4ae55","name":"sales","stream_id":11,"subscribers":["emailgateway@zulip.com",
+ *      "webhook-bot@zulip.com","welcome-bot@zulip.com","notification-bot@zulip.com",
+ *      "new-user-bot@zulip.com","nagios-send-bot@zulip.com","nagios-receive-bot@zulip.com",
+ *      "error-bot@zulip.com","default-bot@zulip.com","iago@zulip.com","prospero@zulip.com",
+ *      "othello@zulip.com","AARON@zulip.com"],"invite_only":false,"audible_notifications":true,"email_address":"sales+51d742945283fef74dc08bdd4d251dde@localhost:9991",
+ *      "pin_to_top":false,"in_home_view":true}],"type":"subscription","id":14,"op":"add"}
+ *
+ * UPDATE operation {"name":"sales","id":15,"property":"color","type":"subscription",
+ *      "email":"AARON@zulip.com","value":"#c2c2c2","op":"update"}
+ *
+ * REMOVE operation {"subscriptions":[{"stream_id":7,"name":"design"}],"type":"subscription","id":16,"op":"remove"}
+ *
+ * {@link SubscriptionWrapper#operation} signifies the operation of the event
+ * namely : add {@link SubscriptionWrapper#OPERATION_ADD},
+ * update {@link SubscriptionWrapper#OPERATION_UPDATE} and
+ * remove {@link SubscriptionWrapper#OPERATION_REMOVE}.
+ *
+ * {@link SubscriptionWrapper#property} holds the property updated and {@link SubscriptionWrapper#value}
+ * holds the updated value of this property.
  */
 
 public class SubscriptionWrapper extends EventsBranch {
@@ -50,16 +71,23 @@ public class SubscriptionWrapper extends EventsBranch {
         this.operation = operation;
     }
 
-    public Stream getUpdatedStream() {
+    /**
+     * This function returns the updated stream object in case of an update subscription event.
+     *
+     * @param app {@link ZulipApp} instance
+     * @return updated {@link Stream} object
+     */
+    public Stream getUpdatedStream(ZulipApp app) {
         if (this.operation.equalsIgnoreCase(SubscriptionWrapper.OPERATION_UPDATE)) {
-            // TODO: account for other updates as well
+            // TODO: account for other updates
             if (property.equalsIgnoreCase("color")) {
-                Stream stream = Stream.getByName(ZulipApp.get(), streamName);
+                // color of stream is changed
+                Stream stream = Stream.getByName(app, streamName);
                 stream.setFetchColor((String) this.value);
                 return stream;
             } else if (property.equalsIgnoreCase("in_home_view")) {
-                // stream mute unmute
-                Stream stream = Stream.getByName(ZulipApp.get(), streamName);
+                // stream is muted or unmuted
+                Stream stream = Stream.getByName(app, streamName);
                 stream.setInHomeView((boolean) this.value);
                 return stream;
             }

--- a/app/src/main/java/com/zulip/android/networking/response/events/SubscriptionWrapper.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/SubscriptionWrapper.java
@@ -1,0 +1,70 @@
+package com.zulip.android.networking.response.events;
+
+import com.google.gson.annotations.SerializedName;
+import com.zulip.android.ZulipApp;
+import com.zulip.android.models.Stream;
+
+import java.util.List;
+
+/**
+ * TODO: add description
+ */
+
+public class SubscriptionWrapper extends EventsBranch {
+
+    public static final String OPERATION_ADD = "add";
+    public static final String OPERATION_REMOVE = "remove";
+    public static final String OPERATION_UPDATE = "update";
+
+    @SerializedName("subscriptions")
+    private List<Stream> streams;
+
+    @SerializedName("op")
+    private String operation;
+
+    @SerializedName("name")
+    private String streamName;
+
+    @SerializedName("property")
+    private String property;
+
+    @SerializedName("email")
+    private String email;
+
+    @SerializedName("value")
+    private Object value;
+
+    public List<Stream> getStreams() {
+        return this.streams;
+    }
+
+    public void setStreams(List<Stream> streams) {
+        this.streams = streams;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+
+    public Stream getUpdatedStream() {
+        if (this.operation.equalsIgnoreCase(SubscriptionWrapper.OPERATION_UPDATE)) {
+            // TODO: account for other updates as well
+            if (property.equalsIgnoreCase("color")) {
+                Stream stream = Stream.getByName(ZulipApp.get(), streamName);
+                stream.setFetchColor((String) this.value);
+                return stream;
+            } else if (property.equalsIgnoreCase("in_home_view")) {
+                // stream mute unmute
+                Stream stream = Stream.getByName(ZulipApp.get(), streamName);
+                stream.setInHomeView((boolean) this.value);
+                return stream;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
EDIT:
Currently stream objects retrieved from messages are null throughout the project. I have corrected this by querying a stream object when we fetch new messages.

- listen for add, remove and update operations for subscription type events
- listen for muted topics events.
- in user configuration response, also get unsubscribed streams to ensure streams are not null in the message list.