### PR TITLE
Fixes #288 Auto close DrawerLayout on selecting particular stream

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -1143,7 +1143,7 @@ public class ZulipActivity extends BaseActivity implements
                 resetStreamSearch();
                 String streamName = ((TextView) view.findViewById(R.id.name)).getText().toString();
                 doNarrow(new NarrowFilterStream(streamName, null));
-                drawerLayout.openDrawer(GravityCompat.START);
+                drawerLayout.closeDrawer(GravityCompat.START);
                 if (previousClick != -1 && expandableListView.getCount() > previousClick) {
                     expandableListView.collapseGroup(previousClick);
                 }


### PR DESCRIPTION
This PR fixes issue #288. `DrawerLayout` is now closing itself as soon as click is made.

![giphy](https://cloud.githubusercontent.com/assets/15157620/21766795/8163b6b4-d696-11e6-901d-93b55bded296.gif)