### PR TITLE
Fixes #287 Bug in textColor of EditText

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -317,6 +317,7 @@ public class ZulipActivity extends BaseActivity implements
         sendBtn = (ImageView) findViewById(R.id.send_btn);
         cameraBtn = (ImageView) findViewById(R.id.camera_btn);
         appBarLayout = (AppBarLayout) findViewById(R.id.appBarLayout);
+        boolean isCurrentThemeNight = (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES);
         etSearchPeople = (EditText) findViewById(R.id.people_drawer_search);
         ivSearchPeopleCancel = (ImageView) findViewById(R.id.iv_people__search_cancel_button);
         onTextChangeOfPeopleSearchEditText();
@@ -328,6 +329,10 @@ public class ZulipActivity extends BaseActivity implements
             }
         });
         etSearchStream = (EditText) findViewById(R.id.stream_drawer_search);
+        if (isCurrentThemeNight) {
+            etSearchPeople.setTextColor(ContextCompat.getColor(this, R.color.color_text_black));
+            etSearchStream.setTextColor(ContextCompat.getColor(this, R.color.color_text_black));
+        }
         ivSearchStreamCancel = (ImageView) findViewById(R.id.iv_stream_search_cancel_button);
         onTextChangeOfStreamSearchEditText();
         ivSearchStreamCancel.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -12,6 +12,7 @@
     <color name="colorTextPrimary">@android:color/primary_text_dark</color>
     <color name="colorTextSecondary">@android:color/secondary_text_dark</color>
     <color name="colorTextTertiary">@android:color/tertiary_text_dark</color>
+    <color name="color_text_black">#000000</color>
     <color name="windowBackground">#616161</color>
     <color name="listBackground">#262626</color>
     <color name="loadingBackground">#757575</color>


### PR DESCRIPTION
This PR fixes #287.
 As this issue was only with dark theme hence it first check as if current theme is _dark_ or not. If yes, then it changes editText color to `colorPrimary` to macth with dark theme properly.