### PR TITLE
Setup zulip server and install android sdk to run tests on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,38 @@
-language: android
+dist: trusty
+language: java
 jdk: oraclejdk8
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-android:
-  components:
-    # use the latest revision of Android SDK Tools
-    - tools
-    - platform-tools
+sudo: required
 
-    # The BuildTools version used by your project
-    - build-tools-23.0.2
+# set android sdk environment variable
+env:
+  - ANDROID_HOME=$HOME/android-sdk-linux
 
-    # The SDK version used to compile your project
-    - android-24
+before_install:
+   - nvm install 0.10
+   - pip install coveralls
+   - sudo apt-get install lib32stdc++6 lib32z1
 
-    # Additional components
-    - extra-google-google_play_services
-    - extra-google-m2repository
-    - extra-android-m2repository
+install:
+  # Disable Travis CI's built-in NVM installation
+  - mv ~/.nvm ~/.travis-nvm-disabled
+  - ./setup_server.sh
+  - ./installSDK.sh
 
-    # uncomment when we enable espresso tests
-    # - sys-img-armeabi-v7a-android-21
+# Emulator Management: Create
+before_script:
+  - export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
+  - echo no | android create avd --force -n test -t android-24 --abi armeabi-v7a
 
-  licenses:
-   - 'android-sdk-license-.+'
-
-# uncomment the following lines to use emulator while runnning espresso tests
-# Emulator Management: Create, Start and Wait
-#before_script:
-#  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
-#  - emulator -avd test -no-skin -no-audio -no-window &
-#  - android-wait-for-emulator
-#  - adb shell input keyevent 82 &
-
-# run gradle lint and
-# gradle build without using using tests for now (assemble) on debug build only
+# run gradle lint and gradle build without using using tests for now (assemble)
+# on debug build only
 script:
+#uncomment the code below when tests are not flaky
+#  - ./getIp.sh
+#  - ./run.sh
   - ./gradlew lintDebug
   - ./gradlew assembleDebug
+addons:
+  postgresql: "9.3"
+  apt:
+    packages:
+      - iproute2

--- a/getIp.sh
+++ b/getIp.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+# get ip address of host
+OUTPUT="$(ip a | grep inet | sed -n '2p')"
+arr=(${OUTPUT})
+echo ${arr[1]} | cut -f1 -d'/'
+ipAddress="$(echo ${arr[1]} | cut -f1 -d'/')"
+
+# set ipaddress append with port 9991 as server url in BaseTest and LoginDevAuthTest
+sed -i "51s/.*/config.vm.network “forwarded_port”, guest: 9991, host: host_port, host_ip: \"0.0.0.0\"/" zulip/Vagrantfile
+sed -i "42s/.*/    private static String SERVER_URL = \"http:\/\/${ipAddress}:9991\";/" app/src/androidTest/java/com/zulip/android/activities/LoginDevAuthTest.java
+sed -i "40s/.*/    public static final String SERVER_URL = \"http:\/\/${ipAddress}:9991\";/" app/src/androidTest/java/com/zulip/android/activities/BaseTest.java

--- a/installSDK.sh
+++ b/installSDK.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# install sdk
+curl --location http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz | tar -x -z -C $HOME
+export ANDROID_HOME=$HOME/android-sdk-linux
+export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
+
+# update sdk with build tools and other components used by the project
+( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk -u -a -t 1,2,11,34,64,166,172,173

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# enable auth backends
+sed -i "19s/.*/AUTHENTICATION_BACKENDS = ('zproject.backends.EmailAuthBackend',)/" zulip/zproject/dev_settings.py
+
+# run server and emulator in parallel
+./runServer.sh &
+./runTests.sh
+wait

--- a/runServer.sh
+++ b/runServer.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+# starts the development server
+cd zulip
+source tools/travis/activate-venv
+./tools/run-dev.py

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+#Start the emulator
+$ANDROID_HOME/tools/emulator -avd test -no-window -wipe-data &
+EMULATOR_PID=$!
+
+# Wait for Android to finish booting
+WAIT_CMD="$ANDROID_HOME/platform-tools/adb wait-for-device shell getprop init.svc.bootanim"
+until $WAIT_CMD | grep -m 1 stopped; do
+  echo "Waiting..."
+  sleep 1
+done
+
+# Unlock the Lock Screen
+$ANDROID_HOME/platform-tools/adb shell input keyevent 82
+
+
+# Run the tests
+./gradlew connectedDebugAndroidTest -i
+
+# save exit code of previous command
+$exit_code = 0
+if [$?]
+then
+    $exit_code = 0
+else
+    $exit_code = 1
+fi
+
+# Stop the background processes
+kill $EMULATOR_PID
+
+# fail tests when error occurs
+exit $exit_code

--- a/setup_server.sh
+++ b/setup_server.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+git clone https://github.com/zulip/zulip.git
+cd zulip
+
+# From a clone of zulip.git
+./tools/travis/setup-backend
+tools/clean-venv-cache --travis
+cd ..


### PR DESCRIPTION
This pr addresses #271 
Since dist trusty is not compatible with android on travis we need to install android sdk and other support libraries manually in order to make use of trusty to run zulip dev environment.

The existing tests are flaked (verified by me and kunal) so they have been commented out for now.