### PR TITLE
Fixes #290: Add edit message feature

### DIFF
--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -37,6 +37,7 @@ import com.zulip.android.networking.ZulipInterceptor;
 import com.zulip.android.networking.response.UserConfigurationResponse;
 import com.zulip.android.networking.response.events.EventsBranch;
 import com.zulip.android.service.ZulipServices;
+import com.zulip.android.util.Constants;
 import com.zulip.android.util.GoogleAuthHelper;
 import com.zulip.android.util.ZLog;
 
@@ -532,4 +533,36 @@ public class ZulipApp extends Application {
                 });
     }
 
+    /**
+     * Sets message content editing parameters
+     *
+     * @param seconds time limit in seconds for editing message
+     * @param param   parameter indicating editing message is allowed or not
+     */
+    public void setMessageContentEditParams(int seconds, boolean param) {
+        SharedPreferences preferences = getSettings();
+        SharedPreferences.Editor editor = preferences.edit();
+
+        //Firsts Checks if maximum content edit limit is already saved or not
+        if (!preferences.getBoolean(Constants.IS_CONTENT_EDIT_PARAM_SAVED, false)) {
+            editor.putBoolean(Constants.IS_EDITING_ALLOWED, param);
+            editor.putInt(Constants.MAXIMUM_CONTENT_EDIT_LIMIT, seconds);
+            editor.putBoolean(Constants.IS_CONTENT_EDIT_PARAM_SAVED, true);
+            editor.apply();
+        } else {
+            //Check if any value is changed from server
+            if (getSettings().getInt(Constants.MAXIMUM_CONTENT_EDIT_LIMIT,
+                    Constants.DEFAULT_MAXIMUM_CONTENT_EDIT_LIMIT) != seconds) {
+                //time is changed from server and update it locally too
+                editor.putInt(Constants.MAXIMUM_CONTENT_EDIT_LIMIT, seconds);
+                editor.apply();
+            }
+            if (getSettings().getBoolean(Constants.IS_EDITING_ALLOWED,
+                    Constants.DEFAULT_EDITING_ALLOWED) != param) {
+                //isEditingAllowed is changed from server and update it locally too
+                editor.putBoolean(Constants.IS_EDITING_ALLOWED, param);
+                editor.apply();
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -358,7 +358,8 @@ public class MessageListFragment extends Fragment implements MessageListener {
                     progress.setCancelable(false);
                     progress.setMessage(app.getString(R.string.editing_message));
                     progress.show();
-                    final String editedMessageContent = dialogMessageEditText.getText().toString();
+                    final String editedMessageContent =
+                            dialogMessageEditText.getText().toString().length() == 0 ? getString(R.string.default_delete_text) : dialogMessageEditText.getText().toString();
 
                     app.getZulipServices()
                             .editMessage(String.valueOf(message.getID()), editedMessageContent)

--- a/app/src/main/java/com/zulip/android/models/Message.java
+++ b/app/src/main/java/com/zulip/android/models/Message.java
@@ -585,7 +585,7 @@ public class Message {
         return formattedContent;
     }
 
-    private void setFormattedContent(String formattedContent) {
+    public void setFormattedContent(String formattedContent) {
         this.formattedContent = formattedContent;
     }
 

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
@@ -18,6 +18,7 @@ import com.zulip.android.models.MessageRange;
 import com.zulip.android.models.Person;
 import com.zulip.android.models.Stream;
 import com.zulip.android.networking.response.UserConfigurationResponse;
+import com.zulip.android.networking.response.events.EditMessageWrapper;
 import com.zulip.android.networking.response.events.EventsBranch;
 import com.zulip.android.networking.response.events.GetEventResponse;
 import com.zulip.android.networking.response.events.MessageWrapper;
@@ -116,6 +117,8 @@ public class AsyncGetEvents extends Thread {
             app.setLastEventId(res.getLastEventId());
             app.setPointer(res.getPointer());
             app.setMaxMessageId(res.getMaxMessageId());
+            app.setMessageContentEditParams(res.getRealmMessageContentEditLimitSeconds(),
+                    res.isRealmAllowMessageEditing());
             registeredOrGotEventsThisRun = true;
             processRegister(res);
         }
@@ -338,6 +341,13 @@ public class AsyncGetEvents extends Thread {
             processMessages(messages);
         }
 
+        //get message time limit events
+        List<EventsBranch> messageTimeLimit = events.getEventsOfBranchType(EventsBranch.BranchType.EDIT_MESSAGE_TIME_LIMIT);
+        if (!messageTimeLimit.isEmpty()) {
+            Log.i("AsyncGetEvents", "Received " + messageTimeLimit.size()
+                    + " realm event");
+            processMessageEditParam(messageTimeLimit);
+        }
     }
 
     /**
@@ -438,5 +448,15 @@ public class AsyncGetEvents extends Thread {
                 mActivity.checkAndSetupStreamsDrawer();
             }
         });
+    }
+
+    private void processMessageEditParam(List<EventsBranch> messageEditLimitEvents) {
+        for (EventsBranch wrapper : messageEditLimitEvents) {
+            EditMessageWrapper timeLimitResponse = (EditMessageWrapper) wrapper;
+            app.setMessageContentEditParams(
+                    timeLimitResponse.getData().getMessageContentEditLimitSeconds(),
+                    timeLimitResponse.getData().isMessageEditingAllowed()
+            );
+        }
     }
 }

--- a/app/src/main/java/com/zulip/android/networking/response/EditResponse.java
+++ b/app/src/main/java/com/zulip/android/networking/response/EditResponse.java
@@ -1,0 +1,20 @@
+package com.zulip.android.networking.response;
+
+import com.google.gson.annotations.SerializedName;
+
+public class EditResponse {
+
+    @SerializedName("msg")
+    private String msg;
+
+    @SerializedName("result")
+    private String result;
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public String getResult() {
+        return result;
+    }
+}

--- a/app/src/main/java/com/zulip/android/networking/response/events/EditMessageWrapper.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/EditMessageWrapper.java
@@ -1,0 +1,32 @@
+package com.zulip.android.networking.response.events;
+
+import com.google.gson.annotations.SerializedName;
+
+public class EditMessageWrapper extends EventsBranch {
+    @SerializedName("data")
+    private Data data;
+
+    public Data getData() {
+        return data;
+    }
+
+    public void setData(Data data) {
+        this.data = data;
+    }
+
+    public class Data {
+        @SerializedName("allow_message_editing")
+        private boolean isMessageEditingAllowed;
+
+        @SerializedName("message_content_edit_limit_seconds")
+        private int messageContentEditLimitSeconds;
+
+        public boolean isMessageEditingAllowed() {
+            return isMessageEditingAllowed;
+        }
+
+        public int getMessageContentEditLimitSeconds() {
+            return messageContentEditLimitSeconds;
+        }
+    }
+}

--- a/app/src/main/java/com/zulip/android/networking/response/events/EventsBranch.java
+++ b/app/src/main/java/com/zulip/android/networking/response/events/EventsBranch.java
@@ -25,7 +25,9 @@ public class EventsBranch {
         MESSAGE(MessageWrapper.class, "message"),
         PRESENCE(PresenceWrapper.class, "presence"),
         SUBSCRIPTIONS(SubscriptionWrapper.class, "subscription"),
-        MUTED_TOPICS(MutedTopicsWrapper.class, "muted_topics");
+        MUTED_TOPICS(MutedTopicsWrapper.class, "muted_topics"),
+        EDIT_MESSAGE_TIME_LIMIT(EditMessageWrapper.class, "realm");
+
 
         private final Class<? extends EventsBranch> klazz;
         private final String key;

--- a/app/src/main/java/com/zulip/android/service/ZulipServices.java
+++ b/app/src/main/java/com/zulip/android/service/ZulipServices.java
@@ -1,6 +1,7 @@
 package com.zulip.android.service;
 
 import com.zulip.android.filters.NarrowFilter;
+import com.zulip.android.networking.response.EditResponse;
 import com.zulip.android.networking.response.GetMessagesResponse;
 import com.zulip.android.networking.response.LoginResponse;
 import com.zulip.android.networking.response.UploadResponse;
@@ -15,9 +16,11 @@ import retrofit2.http.Field;
 import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
 import retrofit2.http.Multipart;
+import retrofit2.http.PATCH;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
 import retrofit2.http.Part;
+import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 
@@ -58,4 +61,8 @@ public interface ZulipServices {
     @Multipart
     @POST("v1/user_uploads")
     Call<UploadResponse> upload(@Part MultipartBody.Part file);
+
+    @FormUrlEncoded
+    @PATCH("v1/messages/{id}")
+    Call<EditResponse> editMessage(@Path("id") String messageId, @Field("content") String messageContent);
 }

--- a/app/src/main/java/com/zulip/android/util/Constants.java
+++ b/app/src/main/java/com/zulip/android/util/Constants.java
@@ -7,4 +7,11 @@ package com.zulip.android.util;
 public class Constants {
     public static int MILLISECONDS_IN_A_MINUTE = 1000;
     public static String DATE_FORMAT = "dd/MM/yyyy";
+    public final static String IS_CONTENT_EDIT_PARAM_SAVED = "isContentEditParamSaved";
+    public final static String IS_EDITING_ALLOWED = "isEditingAllowed";
+    public final static String MAXIMUM_CONTENT_EDIT_LIMIT = "maximumContentEditLimit";
+    //Default maximum time limit for editing message(Same as server)
+    public final static int DEFAULT_MAXIMUM_CONTENT_EDIT_LIMIT = 600;
+    public final static boolean DEFAULT_EDITING_ALLOWED = true;
+
 }

--- a/app/src/main/java/com/zulip/android/viewholders/MessageHolder.java
+++ b/app/src/main/java/com/zulip/android/viewholders/MessageHolder.java
@@ -58,12 +58,21 @@ public class MessageHolder extends RecyclerView.ViewHolder implements View.OnCli
         if (msg.getType().equals(MessageType.STREAM_MESSAGE)) {
             MenuInflater inflater = ((Activity) v.getContext()).getMenuInflater();
             inflater.inflate(R.menu.context_stream, menu);
+            if (msg.getSender().getId() != ZulipApp.get().getYou().getId()){
+                menu.findItem(R.id.edit_message).setVisible(false);
+            }
         } else if (msg.getPersonalReplyTo(ZulipApp.get()).length > 1) {
             MenuInflater inflater = ((Activity) v.getContext()).getMenuInflater();
             inflater.inflate(R.menu.context_private, menu);
+            if (msg.getSender().getId() != ZulipApp.get().getYou().getId()){
+                menu.findItem(R.id.edit_message).setVisible(false);
+            }
         } else {
             MenuInflater inflater = ((Activity) v.getContext()).getMenuInflater();
             inflater.inflate(R.menu.context_single_private, menu);
+            if (msg.getSender().getId() != ZulipApp.get().getYou().getId()){
+                menu.findItem(R.id.edit_message).setVisible(false);
+            }
         }
     }
 

--- a/app/src/main/res/layout/message_edit_dialog.xml
+++ b/app/src/main/res/layout/message_edit_dialog.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="24dp"
+        android:orientation="vertical">
+
+        <EditText
+            android:id="@+id/message_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/edit_message"
+            android:inputType="textCapSentences|textMultiLine"
+            android:maxLines="4" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/menu/context_private.xml
+++ b/app/src/main/res/menu/context_private.xml
@@ -13,4 +13,7 @@
         android:id="@+id/copy_message"
         android:title="@string/copy_message" />
 
+    <item
+        android:id="@+id/edit_message"
+        android:title="@string/edit_message" />
 </menu>

--- a/app/src/main/res/menu/context_single_private.xml
+++ b/app/src/main/res/menu/context_single_private.xml
@@ -9,4 +9,7 @@
     <item
         android:id="@+id/copy_message"
         android:title="@string/copy_message" />
+    <item
+        android:id="@+id/edit_message"
+        android:title="@string/edit_message" />
 </menu>

--- a/app/src/main/res/menu/context_stream.xml
+++ b/app/src/main/res/menu/context_stream.xml
@@ -16,4 +16,7 @@
         android:id="@+id/copy_message"
         android:title="@string/copy_message" />
 
+    <item
+        android:id="@+id/edit_message"
+        android:title="@string/edit_message" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,12 +21,16 @@
     <string name="press_again_to_exit">Press again to exit</string>
 
     <!-- Used on the indicator when loading messages -->
+    <string name="editing_message">Editing message</string>
     <string name="loading_messages">Loading messages</string>
     <string name="sending_message">Sending</string>
     <string name="search">Search</string>
     <string name="reply_to_private_message">Reply to private message</string>
     <string name="narrow_to_this_conversation">Narrow to this conversation</string>
     <string name="copy_message">Copy message</string>
+    <string name="edit_message">Edit message</string>
+    <string name="message_edit_failed">Error editing message</string>
+    <string name="message_edited">Message Edited</string>
     <string name="stream_txt">Stream</string>
     <string name="arrow">❯</string>
     <string name="toast_no_internet_connection">No internet connection</string>
@@ -131,4 +135,6 @@
         <item quantity="one">%d new message</item>
         <item quantity="other">%d new messages</item>
     </plurals>
+    <string name="maximum_time_limit_error">Maximum time limit exceeded</string>
+    <string name="editing_message_disabled">Editing message is disabled</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,4 +137,5 @@
     </plurals>
     <string name="maximum_time_limit_error">Maximum time limit exceeded</string>
     <string name="editing_message_disabled">Editing message is disabled</string>
+    <string name="default_delete_text">(deleted)</string>
 </resources>


### PR DESCRIPTION
This PR fixes #290. 
It includes a feature to edit a message sent (just like web). It has following features:

## 1. On long pressing a message sent by an user.

![rsz_11](https://cloud.githubusercontent.com/assets/15157620/21956506/926786b4-daa8-11e6-9ed0-40f113fb921a.png)

## 2. By selecting `Edit message`, it first checks for the maximum 30 minutes duration.
- If time duration exceeds 30 minutes. then it shows a Toast like this:  

![rsz_2](https://cloud.githubusercontent.com/assets/15157620/21956509/99c56f84-daa8-11e6-8a80-664b153edd52.png)

- Else pops up a Dialog Box to edit message content like this:

![rsz_13](https://cloud.githubusercontent.com/assets/15157620/21956511/ae9264d0-daa8-11e6-9bfc-f5d395cc798d.png)

## 3. After user edit content and clicks `OK` then a `ProgressDialog` starts stating `Editing message` like this:
![rsz_14](https://cloud.githubusercontent.com/assets/15157620/21956513/b446eee6-daa8-11e6-846c-5d8876c36330.png)

Meanwhile a `PATCH` request is made to server for editing the content of message. 
## 4. If message is successfully edited then a Toast appears saying `Message Edited`.
 
![rsz_15](https://cloud.githubusercontent.com/assets/15157620/21956514/c660d8bc-daa8-11e6-9bb0-0c20d5412700.png)
Meanwhile `RecyclerView` is also notified about the data set changed.

@kunall17 @timabbott Please review this PR.