### PR TITLE
Fixes #320 : Retaining edittext's data on screen orientation resolved

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,7 +65,8 @@
         </activity>
         <activity
             android:name=".activities.LoginActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
         </activity>
         <activity
             android:name=".activities.LegalActivity"


### PR DESCRIPTION
This PR addresses #320 

![videotogif_2017 01 24_01 21 56](https://cloud.githubusercontent.com/assets/12701036/22220534/0f683388-e1d5-11e6-876b-56773a87c247.gif)
