### PR TITLE
Added a better progress bar at the bottom/top of feed

### DIFF
--- a/app/src/main/res/drawable/progress_background_circle.xml
+++ b/app/src/main/res/drawable/progress_background_circle.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size
+        android:width="56dp"
+        android:height="56dp" />
+    <solid android:color="@color/progress_background_color" />
+</shape>

--- a/app/src/main/res/layout/list_loading.xml
+++ b/app/src/main/res/layout/list_loading.xml
@@ -8,25 +8,34 @@ per http://pivotallabs.com/android-tidbits-6-22-2011-hiding-header-views/
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <LinearLayout
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:layout_gravity="center"
         android:background="@color/loadingBackground"
-        android:gravity="center|center_vertical"
         tools:ignore="UselessParent">
 
         <ProgressBar
-            android:layout_width="30dp"
-            android:layout_height="30dp" />
+            android:layout_width="45dp"
+            android:layout_height="45dp"
+            android:layout_centerHorizontal="true"
+            android:layout_centerVertical="true" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingLeft="16dp"
-            android:text="@string/loading_messages"
-            android:textColor="@color/colorTextPrimary"
-            android:textSize="18sp" />
-    </LinearLayout>
+        <ImageView
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_centerHorizontal="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/progress_background_circle"
+            tools:ignore="ContentDescription" />
+
+        <ImageView
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_centerVertical="true"
+            android:layout_centerHorizontal="true"
+            android:src="@drawable/zulip_notification"
+            android:contentDescription="@string/progress_bar_description" />
+    </RelativeLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -29,4 +29,5 @@
     <color name="top_snackbar_show_button_text_color">#d26811</color>
     <color name="top_snackbar_bg_color">#000000</color>
     <color name="top_snackbar_text_color">#ffffff</color>
+    <color name="progress_background_color">#444444</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,6 @@
 
     <!-- Used on the indicator when loading messages -->
     <string name="editing_message">Editing message</string>
-    <string name="loading_messages">Loading messages</string>
     <string name="sending_message">Sending</string>
     <string name="search">Search</string>
     <string name="reply_to_private_message">Reply to private message</string>
@@ -148,4 +147,5 @@
     <string name="editing_message_disabled">Editing message is disabled</string>
     <string name="default_delete_text">(deleted)</string>
     <string name="message_edited_tag">(EDITED)</string>
+    <string name="progress_bar_description">Loading new messages</string>
 </resources>


### PR DESCRIPTION
Fixes #331

This adds a better looking progress bar to the feed. This is similar to that of the website.

![g_20170128_0107193](https://cloud.githubusercontent.com/assets/13676490/22385664/9f30721a-e4f9-11e6-80f1-e7c3303ee511.gif)

@timabbott @kunall17 Can you please review this.