### PR TITLE
Fixes #325: Closes Soft Keyboard if it opens on activity recreation

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -56,6 +56,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewPropertyAnimator;
+import android.view.WindowManager;
 import android.view.animation.Interpolator;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
@@ -553,6 +554,8 @@ public class ZulipActivity extends BaseActivity implements
         handleOnFragmentChange();
         calendar = Calendar.getInstance();
         setupSnackBar();
+        //Hides Keyboard if it was open with focus on an editText before restart of the activity
+        this.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
     }
 
     /**


### PR DESCRIPTION
Fixes #325 

Here I am closing the keyboard if it remains open at startup.