### PR TITLE
Update you in ZulipApp after refresh.

### DIFF
--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -122,6 +122,10 @@ public class ZulipApp extends Application {
         this.zulipActivity = zulipActivity;
     }
 
+    public void setYou(Person you) {
+        this.you = you;
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();

--- a/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
+++ b/app/src/main/java/com/zulip/android/networking/AsyncGetEvents.java
@@ -190,6 +190,11 @@ public class AsyncGetEvents extends Thread {
                             } else {
                                 personDao.update(person);
                             }
+                            if (person.getEmail().equals(app.getEmail())) {
+                                //person is user itself
+                                // update in app.getYou()
+                                app.setYou(person);
+                            }
                         } catch (Exception e) {
                             ZLog.logException(e);
                         }


### PR DESCRIPTION
This PR update `you` in the `zulipApp` whose fields becomes null after refresh as discussed in [this](https://github.com/zulip/zulip-android/pull/317#discussion_r98337381). 