### PR TITLE
Fix menu background color in Day theme

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,6 +12,7 @@
     <style name="AppTheme.DayNight.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="android:itemBackground">@color/colorPrimary</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar">


### PR DESCRIPTION
This PR fixes #223.

Default menu background color in Day Theme before:
![rsz_before](https://cloud.githubusercontent.com/assets/15157620/22440029/edb75326-e757-11e6-9bd5-b7fa63df91ad.png)

This PR fixes background color issue with menu as shown:
![rsz_device-2017-01-31-014630](https://cloud.githubusercontent.com/assets/15157620/22440015/d94657f2-e757-11e6-9afa-e3d534d804d4.png)
