### PR TITLE
Fix minor bug in AutoCompleteTextView

### DIFF
--- a/app/src/main/res/layout/chatbox.xml
+++ b/app/src/main/res/layout/chatbox.xml
@@ -12,6 +12,7 @@
             android:layout_height="wrap_content"
             android:dropDownWidth="fill_parent"
             android:hint="@string/stream_txt"
+            android:maxLines="1"
             android:visibility="visible" />
 
 


### PR DESCRIPTION
This PR fixes limits `maxLines` in [Stream's `AutoCompleteTextView`](https://github.com/zulip/zulip-android/blob/bc5a25f5ceea912f3ea7ea2b88f2e444b16ea87c/app/src/main/res/layout/chatbox.xml#L9) to `1`.

- Without this property, `AutoCompleteTextView` can display multiple lines at a time and thus giving poor User experience.

**Before**
![rsz_stream](https://cloud.githubusercontent.com/assets/15157620/22441799/e7a019bc-e75e-11e6-8d3d-8aab121a9c52.png)

Now, it will work fine because maxLines are limited to one.