### PR TITLE
Update gradle version to 2.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.google.gms:google-services:2.1.0'
     }
 }


### PR DESCRIPTION
This PR updates gradle version to `2.2.3` from `2.2.0` to make Instant run faster.