### PR TITLE
Fix: Crash on dev server login.

### DIFF
--- a/app/src/main/java/com/zulip/android/models/Person.java
+++ b/app/src/main/java/com/zulip/android/models/Person.java
@@ -153,7 +153,7 @@ public class Person {
             // use the person id passed to generate person skeleton object which is consistent
             // with server id.
             person.setId(personId);
-            app.getDao(Person.class).create(person);
+            app.getDao(Person.class).createOrUpdate(person);
         } else {
             boolean changed = false;
             if (name != null && !name.equals(person.name)) {


### PR DESCRIPTION
Since we are now also including sender id while creating the person
object in Person.getOrUpdate(), ormlite createOrUpdate is safe to execute.