### PR TITLE
Fix: Markdown render issues

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -8,7 +8,6 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
-import android.net.Uri;
 import android.support.annotation.ColorInt;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewCompat;
@@ -34,6 +33,7 @@ import com.zulip.android.models.Message;
 import com.zulip.android.models.MessageType;
 import com.zulip.android.models.Person;
 import com.zulip.android.models.Stream;
+import com.zulip.android.util.ConvertDpPx;
 import com.zulip.android.util.MutedTopics;
 import com.zulip.android.util.OnItemClickListener;
 import com.zulip.android.util.UrlHelper;
@@ -379,6 +379,9 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
 
                 messageHolder.contentView.setText(message.getFormattedContent(zulipApp));
                 messageHolder.contentView.setMovementMethod(LinkMovementMethod.getInstance());
+
+                int padding = ConvertDpPx.convertDpToPixel(4);
+                messageHolder.contentView.setShadowLayer(padding, 0, 0, 0);
 
                 final String url = message.extractImageUrl(zulipApp);
                 if (url != null) {

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -21,7 +21,6 @@ import android.database.MatrixCursor;
 import android.database.MergeCursor;
 import android.graphics.Bitmap;
 import android.graphics.PorterDuff;
-import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
@@ -52,13 +51,11 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.util.TypedValue;
-import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewPropertyAnimator;
 import android.view.WindowManager;
-import android.view.Window;
 import android.view.animation.Interpolator;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
@@ -1299,7 +1296,7 @@ public class ZulipActivity extends BaseActivity implements
      *
      * @param streamName stream name
      */
-    private void doNarrowToLastRead(String streamName) {
+    public void doNarrowToLastRead(String streamName) {
         // get last message read in stream
         Message message = Stream.getLastMessageRead(app, streamName);
         if (message != null) {

--- a/app/src/main/java/com/zulip/android/models/Message.java
+++ b/app/src/main/java/com/zulip/android/models/Message.java
@@ -22,6 +22,7 @@ import com.zulip.android.R;
 import com.zulip.android.ZulipApp;
 import com.zulip.android.util.Constants;
 import com.zulip.android.util.CustomHtmlToSpannedConverter;
+import com.zulip.android.util.ListTagHandler;
 import com.zulip.android.util.UrlHelper;
 import com.zulip.android.util.ZLog;
 
@@ -361,7 +362,7 @@ public class Message {
         };
 
         CustomHtmlToSpannedConverter converter = new CustomHtmlToSpannedConverter(
-                source, null, null, parser, emojiGetter, app.getServerURI(), context);
+                source, null, new ListTagHandler(), parser, emojiGetter, app.getServerURI(), context);
 
         return CustomHtmlToSpannedConverter.linkifySpanned(converter.convert(), Linkify.ALL);
     }

--- a/app/src/main/java/com/zulip/android/util/ConvertDpPx.java
+++ b/app/src/main/java/com/zulip/android/util/ConvertDpPx.java
@@ -1,0 +1,35 @@
+package com.zulip.android.util;
+
+import android.content.res.Resources;
+import android.util.DisplayMetrics;
+
+/**
+ * This class is used during conversions between dp and px.
+ */
+
+public class ConvertDpPx {
+
+    /**
+     * This method converts dp unit to equivalent pixels, depending on device density.
+     *
+     * @param dp A value in dp (density independent pixels) unit. Which we need to convert into pixels
+     * @return A float value to represent px equivalent to dp depending on device density
+     */
+    public static int convertDpToPixel(float dp){
+        DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
+        float px = dp * ((float)metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+        return Math.round(px);
+    }
+
+    /**
+     * This method converts device specific pixels to density independent pixels.
+     *
+     * @param px A value in px (pixels) unit. Which we need to convert into db
+     * @return A float value to represent dp equivalent to px value
+     */
+    public static float convertPixelsToDp(float px){
+        DisplayMetrics metrics = Resources.getSystem().getDisplayMetrics();
+        float dp = px / ((float)metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+        return dp;
+    }
+}

--- a/app/src/main/java/com/zulip/android/util/CustomHtmlToSpannedConverter.java
+++ b/app/src/main/java/com/zulip/android/util/CustomHtmlToSpannedConverter.java
@@ -71,6 +71,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
+import static android.R.attr.id;
+
 public class CustomHtmlToSpannedConverter implements ContentHandler {
 
     private static final float[] HEADER_SIZES = {1.5f, 1.4f, 1.3f, 1.2f, 1.1f,
@@ -245,8 +247,13 @@ public class CustomHtmlToSpannedConverter implements ContentHandler {
         String email;
         String stringId = attributes.getValue("data-user-id");
         if (stringId != null) {
-            int id = Integer.parseInt(stringId);
-            email = Person.getById(ZulipApp.get(), id).getEmail();
+            // in case of "@all"
+            if (stringId.equals("*")) {
+                email = stringId;
+            } else {
+                int id = Integer.parseInt(stringId);
+                email = Person.getById(ZulipApp.get(), id).getEmail();
+            }
         } else {
             // for historical messages, revert to use of this attribute
             email = attributes.getValue("data-user-email");

--- a/app/src/main/java/com/zulip/android/util/CustomHtmlToSpannedConverter.java
+++ b/app/src/main/java/com/zulip/android/util/CustomHtmlToSpannedConverter.java
@@ -36,6 +36,7 @@ import android.text.style.ImageSpan;
 import android.text.style.ParagraphStyle;
 import android.text.style.QuoteSpan;
 import android.text.style.RelativeSizeSpan;
+import android.text.style.StrikethroughSpan;
 import android.text.style.StyleSpan;
 import android.text.style.SubscriptSpan;
 import android.text.style.SuperscriptSpan;
@@ -525,6 +526,12 @@ public class CustomHtmlToSpannedConverter implements ContentHandler {
             start(mSpannableStringBuilder, new InlineCode());
         } else if (tag.equalsIgnoreCase("pre")) {
             start(mSpannableStringBuilder, new CodeBlock());
+        } else if (tag.equalsIgnoreCase("del")) {
+            start(mSpannableStringBuilder, new StrikeThrough());
+        } else if (tag.equalsIgnoreCase("s")) {
+            start(mSpannableStringBuilder, new StrikeThrough());
+        } else if (tag.equalsIgnoreCase("strike")) {
+            start(mSpannableStringBuilder, new StrikeThrough());
         } else if (tag.length() == 2
                 && Character.toLowerCase(tag.charAt(0)) == 'h'
                 && tag.charAt(1) >= '1' && tag.charAt(1) <= '6') {
@@ -599,6 +606,12 @@ public class CustomHtmlToSpannedConverter implements ContentHandler {
         } else if (tag.equalsIgnoreCase("pre")) {
             end(mSpannableStringBuilder, CodeBlock.class, new TypefaceSpan(
                     MONOSPACE));
+        } else if (tag.equalsIgnoreCase("del")) {
+            end(mSpannableStringBuilder, StrikeThrough.class, new StrikethroughSpan());
+        } else if (tag.equalsIgnoreCase("s")) {
+            end(mSpannableStringBuilder, StrikeThrough.class, new StrikethroughSpan());
+        } else if (tag.equalsIgnoreCase("strike")) {
+            end(mSpannableStringBuilder, StrikeThrough.class, new StrikethroughSpan());
         } else if (tag.length() == 2
                 && Character.toLowerCase(tag.charAt(0)) == 'h'
                 && tag.charAt(1) >= '1' && tag.charAt(1) <= '6') {
@@ -716,6 +729,9 @@ public class CustomHtmlToSpannedConverter implements ContentHandler {
     }
 
     private static class CodeBlock {
+    }
+
+    private static class StrikeThrough {
     }
 
     private static class Font {

--- a/app/src/main/java/com/zulip/android/util/ListTagHandler.java
+++ b/app/src/main/java/com/zulip/android/util/ListTagHandler.java
@@ -1,0 +1,186 @@
+package com.zulip.android.util;
+
+import android.text.Editable;
+import android.text.Html;
+import android.text.Spanned;
+import android.text.style.BulletSpan;
+import android.text.style.LeadingMarginSpan;
+import android.util.Log;
+
+import org.xml.sax.XMLReader;
+
+import java.util.Stack;
+
+/**
+ * Custom TagHandler {@link Html.TagHandler} to support ordered and unordered list in
+ * TextView {@link android.widget.TextView}.
+ */
+
+public class ListTagHandler implements Html.TagHandler {
+    private static final String LOG_TAG = ListTagHandler.class.getSimpleName();
+
+    private static final String OL_TAG = "ol";
+    private static final String UL_TAG = "ul";
+    private static final String LI_TAG = "li";
+
+    /**
+     * List indentation in pixels.
+     */
+    private static final int INDENT_PX = 10;
+    private static final int LIST_ITEM_INDENT_PX = INDENT_PX * 2;
+    private static final BulletSpan BULLET_SPAN = new BulletSpan(INDENT_PX);
+
+    /**
+     * Keeps track of lists (ol, ul). On bottom of Stack is the outermost list
+     * and on top of Stack is the most nested list.
+     */
+    private final Stack<ListTag> lists = new Stack<ListTag>();
+
+    @Override
+    public void handleTag(final boolean opening, final String tag, final Editable output, final XMLReader xmlReader) {
+        if (UL_TAG.equalsIgnoreCase(tag)) {
+            if (opening) {
+                // handle <ul>
+                lists.push(new Ul());
+            } else {
+                // handle </ul>
+                lists.pop();
+            }
+        } else if (OL_TAG.equalsIgnoreCase(tag)) {
+            if (opening) {
+                // handle <ol>
+                // use default start index of 1
+                lists.push(new Ol());
+            } else {
+                // handle </ol>
+                lists.pop();
+            }
+        } else if (LI_TAG.equalsIgnoreCase(tag)) {
+            if (opening) {
+                // handle <li>
+                lists.peek().openItem(output);
+            } else {
+                // handle </li>
+                lists.peek().closeItem(output, lists.size());
+            }
+        } else {
+            Log.d(LOG_TAG, "Found an unsupported tag " + tag);
+        }
+    }
+
+    /**
+     * Abstract super class for {@link Ul} and {@link Ol}.
+     */
+    private abstract static class ListTag {
+        /**
+         * Opens a new list item.
+         *
+         * @param text
+         */
+        public void openItem(final Editable text) {
+            if (text.length() > 0 && text.charAt(text.length() - 1) != '\n') {
+                text.append("\n");
+            }
+            final int len = text.length();
+            text.setSpan(this, len, len, Spanned.SPAN_MARK_MARK);
+        }
+
+        /**
+         * Closes a list item.
+         *
+         * @param text
+         * @param indentation
+         */
+        public final void closeItem(final Editable text, final int indentation) {
+            if (text.length() > 0 && text.charAt(text.length() - 1) != '\n') {
+                text.append("\n");
+            }
+            final Object[] replaces = getReplaces(text, indentation);
+            final int len = text.length();
+            final ListTag listTag = getLast(text);
+            final int where = text.getSpanStart(listTag);
+            text.removeSpan(listTag);
+            if (where != len) {
+                for (Object replace : replaces) {
+                    text.setSpan(replace, where, len, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                }
+            }
+        }
+
+        protected abstract Object[] getReplaces(final Editable text, final int indentation);
+
+        /**
+         * Note: This knows that the last returned object from getSpans() will be the most recently added.
+         */
+        private ListTag getLast(final Spanned text) {
+            final ListTag[] listTags = text.getSpans(0, text.length(), ListTag.class);
+            if (listTags.length == 0) {
+                return null;
+            }
+            return listTags[listTags.length - 1];
+        }
+    }
+
+    /**
+     * Class representing the unordered list <ul></ul> HTML tag.
+     */
+    private static class Ul extends ListTag {
+
+        @Override
+        protected Object[] getReplaces(final Editable text, final int indentation) {
+            // Nested BulletSpans increases distance between BULLET_SPAN and text, so we must prevent it.
+            int bulletMargin = INDENT_PX;
+            if (indentation > 1) {
+                bulletMargin = INDENT_PX - BULLET_SPAN.getLeadingMargin(true);
+                if (indentation > 2) {
+                    // This get's more complicated when we add a LeadingMarginSpan into the same line:
+                    // we have also counter it's effect to BulletSpan
+                    bulletMargin -= (indentation - 2) * LIST_ITEM_INDENT_PX;
+                }
+            }
+            return new Object[]{
+                    new LeadingMarginSpan.Standard(LIST_ITEM_INDENT_PX * (indentation - 1)),
+                    new BulletSpan(bulletMargin)
+            };
+        }
+    }
+
+    /**
+     * Class representing the ordered list <ol></ol> HTML tag.
+     */
+    private static class Ol extends ListTag {
+        private int nextIdx;
+
+        /**
+         * Creates a new <ol></ol> with start index of 1.
+         */
+        public Ol() {
+            this(1); // default start index
+        }
+
+        /**
+         * Creates a new <ol></ol> with given start index.
+         *
+         * @param startIdx
+         */
+        public Ol(final int startIdx) {
+            this.nextIdx = startIdx;
+        }
+
+        @Override
+        public void openItem(final Editable text) {
+            super.openItem(text);
+            text.append(Integer.toString(nextIdx++)).append(". ");
+        }
+
+        @Override
+        protected Object[] getReplaces(final Editable text, final int indentation) {
+            int numberMargin = LIST_ITEM_INDENT_PX * (indentation - 1);
+            if (indentation > 2) {
+                // Same as in ordered lists: counter the effect of nested Spans
+                numberMargin -= (indentation - 2) * LIST_ITEM_INDENT_PX;
+            }
+            return new Object[]{new LeadingMarginSpan.Standard(numberMargin)};
+        }
+    }
+}

--- a/app/src/main/java/com/zulip/android/util/StreamSpan.java
+++ b/app/src/main/java/com/zulip/android/util/StreamSpan.java
@@ -1,0 +1,53 @@
+package com.zulip.android.util;
+
+import android.content.Context;
+import android.text.TextPaint;
+import android.text.style.ClickableSpan;
+import android.view.View;
+
+import com.zulip.android.ZulipApp;
+import com.zulip.android.models.Stream;
+
+/**
+ * Custom ClickableSpan to support #stream-name click. The user is taken to the last message read
+ * in the stream.
+ */
+
+public class StreamSpan extends ClickableSpan {
+    private String streamId;
+    private int color;
+
+    public StreamSpan(String streamId, int color) {
+        this.streamId = streamId;
+        this.color = color;
+    }
+
+    /**
+     * Performs the click action associated with this span.
+     */
+    @Override
+    public void onClick(View widget) {
+        Context context = widget.getContext().getApplicationContext();
+
+        // get stream name from streamId string
+        String streamName = null;
+        if (streamId != null) {
+            Stream stream = Stream.getById(ZulipApp.get(), Integer.parseInt(streamId));
+            if (stream != null) {
+                streamName = stream.getName();
+            }
+        }
+
+        // go to last message read in the stream
+        (((ZulipApp) context).getZulipActivity()).doNarrowToLastRead(streamName);
+    }
+
+    /**
+     * Makes the text underlined and in the link color.
+     */
+    @Override
+    public void updateDrawState(TextPaint ds) {
+        ds.setColor(this.color);
+        ds.setUnderlineText(false);
+    }
+}


### PR DESCRIPTION
This pr addresses part of #272 .

- added support for strikethrough
- fixed formatting for inline code
- fixed formatting for code block
- added support for unordered/ordered lists
- added support for clickable span for #stream-name.

@kunall17 I'll send fixes for rest of the markdown issues in another pr.