### PR TITLE
Add default activity transition animation class.

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -39,6 +39,7 @@ import com.zulip.android.networking.ZulipAsyncPushTask;
 import com.zulip.android.networking.response.LoginResponse;
 import com.zulip.android.networking.response.ZulipBackendResponse;
 import com.zulip.android.networking.util.DefaultCallback;
+import com.zulip.android.util.ActivityTransitionAnim;
 import com.zulip.android.util.AnimationHelper;
 import com.zulip.android.util.Constants;
 import com.zulip.android.util.CommonProgressDialog;
@@ -424,6 +425,10 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
         commonProgressDialog.dismiss();
         Intent i = new Intent(this, ZulipActivity.class);
         startActivity(i);
+
+        // activity transition animation
+        ActivityTransitionAnim.transition(this);
+
         finish();
     }
 

--- a/app/src/main/java/com/zulip/android/activities/PhotoEditActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/PhotoEditActivity.java
@@ -22,6 +22,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
 import com.zulip.android.R;
+import com.zulip.android.util.ActivityTransitionAnim;
 import com.zulip.android.util.DrawCustomView;
 import com.zulip.android.util.PhotoHelper;
 
@@ -132,6 +133,9 @@ public class PhotoEditActivity extends AppCompatActivity {
                     cropIntent.putExtra(PhotoEditActivity.class.getSimpleName(), true);
                     cropIntent.putExtra(Intent.EXTRA_TEXT, mPhotoPath);
                     startActivity(cropIntent);
+
+                    // activity transition animation
+                    ActivityTransitionAnim.transition(PhotoEditActivity.this);
                 } else {
                     // do nothing
                     // wait for layout to be constructed
@@ -158,6 +162,9 @@ public class PhotoEditActivity extends AppCompatActivity {
 
                     sendIntent.putExtra(Intent.EXTRA_TEXT, mPhotoPath);
                     startActivity(sendIntent);
+
+                    // activity transition animation
+                    ActivityTransitionAnim.transition(PhotoEditActivity.this);
                 } else {
                     // do nothing
                     // wait for layout to be constructed

--- a/app/src/main/java/com/zulip/android/activities/PhotoSendActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/PhotoSendActivity.java
@@ -21,6 +21,7 @@ import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
 import com.theartofdev.edmodo.cropper.CropImageView;
 import com.zulip.android.R;
+import com.zulip.android.util.ActivityTransitionAnim;
 import com.zulip.android.util.PhotoHelper;
 
 import java.io.File;
@@ -67,6 +68,9 @@ public class PhotoSendActivity extends AppCompatActivity {
 
                 // go back to ZulipActivity to start camera intent
                 startActivity(sendIntent);
+
+                // activity transition animation
+                ActivityTransitionAnim.transition(PhotoSendActivity.this);
             }
         });
 
@@ -139,6 +143,9 @@ public class PhotoSendActivity extends AppCompatActivity {
                 // add the file path of cropped image
                 sendIntent.putExtra(Intent.EXTRA_TEXT, mPhotoPath);
                 startActivity(sendIntent);
+
+                // activity transition animation
+                ActivityTransitionAnim.transition(PhotoSendActivity.this);
             }
         });
 
@@ -168,6 +175,9 @@ public class PhotoSendActivity extends AppCompatActivity {
                 Intent intent = new Intent(PhotoSendActivity.this, PhotoEditActivity.class);
                 intent.putExtra(Intent.EXTRA_TEXT, mPhotoPath);
                 startActivity(intent);
+
+                // activity transition animation
+                ActivityTransitionAnim.transition(PhotoSendActivity.this);
             }
         });
 

--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -1,6 +1,5 @@
 package com.zulip.android.activities;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.ColorStateList;
@@ -34,6 +33,7 @@ import com.zulip.android.models.MessageType;
 import com.zulip.android.models.Person;
 import com.zulip.android.models.Stream;
 import com.zulip.android.util.ConvertDpPx;
+import com.zulip.android.util.ActivityTransitionAnim;
 import com.zulip.android.util.MutedTopics;
 import com.zulip.android.util.OnItemClickListener;
 import com.zulip.android.util.UrlHelper;
@@ -397,7 +397,9 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                                     i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                                     i.putExtra(Intent.EXTRA_TEXT , url);
                                     zulipApp.startActivity(i);
-                                    ((Activity) context).overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
+
+                                    // activity transition animation
+                                    ActivityTransitionAnim.transition(context);
                                 }
                             });
                 } else {

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -2150,6 +2150,10 @@ public class ZulipActivity extends BaseActivity implements
         Intent i = new Intent(this, LoginActivity.class);
         i.putExtra(Constants.SERVER_URL, serverUrl);
         startActivity(i);
+
+        // activity transition animation
+        ActivityTransitionAnim.transition(this);
+
         finish();
     }
 

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -98,6 +98,7 @@ import com.zulip.android.networking.AsyncSend;
 import com.zulip.android.networking.AsyncStatusUpdate;
 import com.zulip.android.networking.ZulipAsyncPushTask;
 import com.zulip.android.networking.response.UploadResponse;
+import com.zulip.android.util.ActivityTransitionAnim;
 import com.zulip.android.util.AnimationHelper;
 import com.zulip.android.util.Constants;
 import com.zulip.android.util.CommonProgressDialog;
@@ -827,6 +828,9 @@ public class ZulipActivity extends BaseActivity implements
             Intent photoSendIntent = new Intent(this, PhotoSendActivity.class);
             photoSendIntent.putExtra(Intent.EXTRA_TEXT, mCurrentPhotoPath);
             startActivity(photoSendIntent);
+
+            // activity transition animation
+            ActivityTransitionAnim.transition(ZulipActivity.this);
         }
     }
 
@@ -912,6 +916,9 @@ public class ZulipActivity extends BaseActivity implements
                 }
 
                 startActivityForResult(takePictureIntent, REQUEST_TAKE_PHOTO);
+
+                // activity transition animation
+                ActivityTransitionAnim.transition(ZulipActivity.this);
             }
         }
     }

--- a/app/src/main/java/com/zulip/android/util/ActivityTransitionAnim.java
+++ b/app/src/main/java/com/zulip/android/util/ActivityTransitionAnim.java
@@ -1,0 +1,22 @@
+package com.zulip.android.util;
+
+import android.app.Activity;
+import android.content.Context;
+
+/**
+ * Default Activity transition animation.
+ */
+
+public class ActivityTransitionAnim {
+    /**
+     * All usages must pass an activity context to execute a transition.
+     *
+     * @param activityContext {@link Context}
+     */
+    public static void transition(Context activityContext) {
+        // avoid invalid class cast exception
+        if (activityContext instanceof Activity) {
+            ((Activity) activityContext).overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
+        }
+    }
+}

--- a/app/src/main/java/com/zulip/android/util/CustomHtmlToSpannedConverter.java
+++ b/app/src/main/java/com/zulip/android/util/CustomHtmlToSpannedConverter.java
@@ -48,13 +48,11 @@ import android.text.style.TypefaceSpan;
 import android.text.style.URLSpan;
 import android.text.style.UnderlineSpan;
 import android.text.util.Linkify;
-import android.util.DisplayMetrics;
 import android.util.Pair;
 
 import com.zulip.android.R;
 import com.zulip.android.ZulipApp;
 import com.zulip.android.models.Person;
-import com.zulip.android.models.Stream;
 
 import org.ccil.cowan.tagsoup.Parser;
 import org.xml.sax.Attributes;
@@ -70,8 +68,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-
-import static android.R.attr.id;
 
 public class CustomHtmlToSpannedConverter implements ContentHandler {
 
@@ -244,7 +240,7 @@ public class CustomHtmlToSpannedConverter implements ContentHandler {
     }
 
     private static void startSpan(SpannableStringBuilder text, Attributes attributes) {
-        String email;
+        String email = null;
         String stringId = attributes.getValue("data-user-id");
         if (stringId != null) {
             // in case of "@all"
@@ -252,7 +248,10 @@ public class CustomHtmlToSpannedConverter implements ContentHandler {
                 email = stringId;
             } else {
                 int id = Integer.parseInt(stringId);
-                email = Person.getById(ZulipApp.get(), id).getEmail();
+                Person person = Person.getById(ZulipApp.get(), id);
+                if (person != null) {
+                    email = person.getEmail();
+                }
             }
         } else {
             // for historical messages, revert to use of this attribute


### PR DESCRIPTION
**Summary of changes**

Added simple fade in/out activity transition animation in util folder and used it in photos feature, login and logout.

Example (during logout the animation looks like this)
![g_20170208_0803193](https://cloud.githubusercontent.com/assets/14239866/22721933/aae23ba0-edd9-11e6-93d7-1273917e5d29.gif)


- [x] Code is formatted.
- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] If new feature is implemeted then it is compatible with Night theme too.

- [x] Commit messages are well-written.
