### PR TITLE
Change color of send status indicator

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -120,7 +120,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                             Person[] recipientArray = messageHeaderParent.getRecipients(zulipApp);
                             narrowListener.onNarrow(new NarrowFilterPM(Arrays.asList(recipientArray)),
                                     messageHeaderParent.getMessageId());
-                            narrowListener.onNarrowFillSendBoxPrivate(recipientArray,false);
+                            narrowListener.onNarrowFillSendBoxPrivate(recipientArray, false);
                         } else {
                             narrowListener.onNarrow(new NarrowFilterStream(Stream.getByName(zulipApp,
                                     messageHeaderParent.getStream()), null),
@@ -354,10 +354,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                     messageHeaderHolder.streamTextView.setText(messageHeaderParent.getStream());
                     messageHeaderHolder.topicTextView.setText(messageHeaderParent.getSubject());
 
-                    if (!isCurrentThemeNight) {
-                        messageHeaderHolder.streamTextView.setBackgroundColor(messageHeaderParent.getColor());
-                        ViewCompat.setBackgroundTintList(messageHeaderHolder.arrowHead, ColorStateList.valueOf(messageHeaderParent.getColor()));
-                    }
+                    ViewCompat.setBackgroundTintList(messageHeaderHolder.arrowHead, ColorStateList.valueOf(messageHeaderParent.getColor()));
                     messageHeaderHolder.streamTextView.setBackgroundColor(messageHeaderParent.getColor());
 
                     if (messageHeaderParent.isMute()) {
@@ -395,7 +392,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                                 public void onClick(View view) {
                                     Intent i = new Intent(zulipApp.getApplicationContext(), PhotoViewActivity.class);
                                     i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                                    i.putExtra(Intent.EXTRA_TEXT , url);
+                                    i.putExtra(Intent.EXTRA_TEXT, url);
                                     zulipApp.startActivity(i);
                                     ((Activity) context).overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                                 }

--- a/app/src/main/res/layout/chatbox.xml
+++ b/app/src/main/res/layout/chatbox.xml
@@ -83,16 +83,18 @@
     <LinearLayout
         android:id="@+id/composeStatus"
         android:layout_width="match_parent"
-        android:layout_height="24dp"
-
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
         android:layout_gravity="center"
-        android:background="#eeeeee"
+        android:background="@color/colorPrimary"
         android:gravity="center|center_vertical"
         android:visibility="gone">
 
         <ProgressBar
             android:layout_width="15dp"
-            android:layout_height="15dp" />
+            android:layout_height="15dp"
+            style="@style/AppTheme.DayNight"
+            />
 
         <TextView
             android:id="@+id/sending_message"
@@ -100,6 +102,7 @@
             android:layout_height="wrap_content"
             android:paddingLeft="8dp"
             android:text="@string/sending_message"
+            android:textColor="@color/colorTextPrimary"
             android:textSize="16sp" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/chatbox.xml
+++ b/app/src/main/res/layout/chatbox.xml
@@ -38,7 +38,8 @@
             android:layout_height="wrap_content"
             android:contentDescription="@string/stream_private_content_desp"
             android:padding="3dp"
-            android:src="@drawable/ic_action_person" />
+            android:src="@drawable/ic_action_person"
+            android:tint="@color/colorTextSecondary" />
     </LinearLayout>
 
     <LinearLayout
@@ -51,13 +52,14 @@
             android:id="@+id/camera_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:alpha="0.7"
             android:contentDescription="@string/camera_content_desp"
             android:paddingBottom="4dp"
             android:paddingLeft="8dp"
             android:paddingRight="4dp"
             android:paddingTop="4dp"
             android:src="@drawable/ic_photo_camera_black_24dp"
-            android:tint="#757575" />
+            android:tint="@color/colorTextSecondary" />
 
         <AutoCompleteTextView
             android:id="@+id/message_et"
@@ -73,10 +75,11 @@
             android:id="@+id/send_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:alpha="0.7"
             android:contentDescription="@string/send_content_desp"
             android:padding="4dp"
             android:src="@drawable/ic_send_24dp"
-            android:tint="#757575" />
+            android:tint="@color/colorTextSecondary" />
 
     </LinearLayout>
 
@@ -84,17 +87,16 @@
         android:id="@+id/composeStatus"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_gravity="center"
         android:background="@color/colorPrimary"
         android:gravity="center|center_vertical"
+        android:orientation="horizontal"
         android:visibility="gone">
 
         <ProgressBar
-            android:layout_width="15dp"
-            android:layout_height="15dp"
             style="@style/AppTheme.DayNight"
-            />
+            android:layout_width="15dp"
+            android:layout_height="15dp" />
 
         <TextView
             android:id="@+id/sending_message"


### PR DESCRIPTION
Fixes #376

The following colours now show in the sending status indicator.

**Night theme:**
![screenshot_20170210-035155](https://cloud.githubusercontent.com/assets/13676490/22805696/cf596758-ef44-11e6-9f4b-ea271760613b.png)

**Day Theme:**

![screenshot_20170210-035259](https://cloud.githubusercontent.com/assets/13676490/22805705/db171d7e-ef44-11e6-85cc-150d6ad664fe.png)

