### PR TITLE
Update build.gradle to Crashlytics 2.6.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'com.android.support:support-v4:24.1.0'
     compile 'com.theartofdev.edmodo:android-image-cropper:2.3.+'
-    compile('com.crashlytics.sdk.android:crashlytics:2.6.2@aar') {
+    compile('com.crashlytics.sdk.android:crashlytics:2.6.6@aar') {
         transitive = true;
     }
 


### PR DESCRIPTION
**Summary of changes**

Updated the build.gradle to Crashlytics 2.6.6 from 2.6.2


- [x] Code is formatted.

- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] Commit messages are well-written.
