### PR TITLE
Auto cancel the PhotoViewActivity download notification

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/PhotoViewActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/PhotoViewActivity.java
@@ -312,6 +312,7 @@ public class PhotoViewActivity extends AppCompatActivity implements ActivityComp
             intent.setDataAndType(uri, "image/*");
             PendingIntent pIntent = PendingIntent.getActivity(PhotoViewActivity.this, 0, intent, 0);
             mBuilder.setContentIntent(pIntent).build();
+            mBuilder.setAutoCancel(true);
             mNotifyManager.notify(id, mBuilder.build());
 
         }


### PR DESCRIPTION
**Summary of changes**

Automatically dismiss the notification of "Download Complete" after clicking on it. 


Screenshots or a brief video showing the change in action:

![videotogif_2017 02 10_06 33 56](https://cloud.githubusercontent.com/assets/21558765/22810070/7379ccf8-ef5c-11e6-9b74-00278937ff93.gif)





- [x] Code is formatted.

- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] Commit messages are well-written.
