### PR TITLE
Fixes #388: Adds missing paddingBottom for private message layout

### DIFF
--- a/app/src/main/res/layout/message_tile.xml
+++ b/app/src/main/res/layout/message_tile.xml
@@ -66,6 +66,7 @@
             android:paddingLeft="8dp"
             android:paddingRight="16dp"
             android:paddingStart="8dp"
+            android:paddingBottom="8dp"
             tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam mollis pretium purus, faucibus accumsan enim placerat non. " />
 
         <FrameLayout


### PR DESCRIPTION
**Summary of changes**

This PR fixes https://github.com/zulip/zulip-android/issues/388
added paddingBottom with 8dp.

Screenshot : 

![screenshot_20170211-015344](https://cloud.githubusercontent.com/assets/21558765/22843204/6cd8d680-effe-11e6-9dd5-6925cbfdfd67.jpg)



- [x] Code is formatted.

- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] Commit messages are well-written.
