### PR TITLE
Fixes #386 : Compose box doesn't auto-open when narrowing

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -1204,6 +1204,8 @@ public class ZulipActivity extends BaseActivity implements
                         String subjectName = ((Cursor) streamsDrawer.getExpandableListAdapter().getChild(groupPosition, childPosition)).getString(0);
                         onNarrow(new NarrowFilterStream(streamName, subjectName));
                         onNarrowFillSendBoxStream(streamName, subjectName, false);
+                        hideView(chatBox);
+                        displayFAB(true);
                         break;
                     default:
                         return false;
@@ -1220,6 +1222,8 @@ public class ZulipActivity extends BaseActivity implements
                 String streamName = ((TextView) view.findViewById(R.id.name)).getText().toString();
                 doNarrowToLastRead(streamName);
                 drawerLayout.openDrawer(GravityCompat.START);
+                hideView(chatBox);
+                displayFAB(true);
                 if (previousClick != -1 && expandableListView.getCount() > previousClick) {
                     expandableListView.collapseGroup(previousClick);
                 }
@@ -1237,6 +1241,8 @@ public class ZulipActivity extends BaseActivity implements
                         TextView name = (TextView) view;
                         final String streamName = cursor.getString(columnIndex);
                         name.setText(streamName);
+                        hideView(chatBox);
+                        displayFAB(true);
                         //Change color in the drawer if this stream is inHomeView only.
                         if (!Stream.getByName(app, streamName).getInHomeView()) {
                             name.setTextColor(ContextCompat.getColor(ZulipActivity.this, R.color.colorTextTertiary));


### PR DESCRIPTION
**Summary of changes**

This PR fixes https://github.com/zulip/zulip-android/issues/386 
Now compose box doesn't auto-open when narrowing.


Screenshots or a brief video showing the change in action:
![chatbox](https://cloud.githubusercontent.com/assets/21558765/22826333/e84e73fc-efb7-11e6-85ea-8b9e3e866e13.gif)


- [x] Code is formatted.

- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] Commit messages are well-written.
