### PR TITLE
Issue#365 Leak in LoginActivity has been removed.

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/DevAuthActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/DevAuthActivity.java
@@ -93,4 +93,13 @@ public class DevAuthActivity extends BaseActivity {
         startActivity(i);
         finish();
     }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (commonProgressDialog != null && commonProgressDialog.isShowing()) {
+            commonProgressDialog.dismiss();
+        }
+    }
+
 }

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -213,6 +213,14 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
         super.onStop();
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (commonProgressDialog != null && commonProgressDialog.isShowing()) {
+            commonProgressDialog.dismiss();
+        }
+    }
+
     private void checkForError() {
         String serverURL = serverIn.getText().toString();
 


### PR DESCRIPTION
**Summary of changes**

LoginActivity was leaked because the commonProgressDialog remain opened even when the activity was not there. So by calling commonProgressDialog.dismiss() in Activity Lifecycle's onDestroy() method the issue has been resolved.

@kunall17 Please review and let me know if you're able to reproduce the issue or not.