### PR TITLE
Better inactive status view

### DIFF
--- a/app/src/main/res/drawable/presence_inactive.xml
+++ b/app/src/main/res/drawable/presence_inactive.xml
@@ -1,6 +1,15 @@
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="ring">
-    <solid android:color="#000000" />
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <solid
+        android:color="@color/solid_color" />
+
+    <stroke
+        android:width="1px"
+        android:color="@color/stroke_color" />
+
     <size
         android:width="16dp"
         android:height="16dp" />

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -27,4 +27,6 @@
     <color name="top_snackbar_show_button_text_color">#d26811</color>
     <color name="top_snackbar_bg_color">#ffffff</color>
     <color name="top_snackbar_text_color">#131313</color>
+    <color name="solid_color">#262626</color>
+    <color name="stroke_color">#FFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -30,4 +30,6 @@
     <color name="top_snackbar_bg_color">#000000</color>
     <color name="top_snackbar_text_color">#ffffff</color>
     <color name="progress_background_color">#444444</color>
+    <color name="solid_color">#FFF</color>
+    <color name="stroke_color">#000</color>
 </resources>


### PR DESCRIPTION
**Summary of changes**
 
Implemented better inactive status view. Just like on web. 

Screenshots or a brief video showing the change in action:

Night mode
![night](https://cloud.githubusercontent.com/assets/21558765/22850748/3cb06040-f035-11e6-8946-e1346ce7524c.png)

Day mode:
![day](https://cloud.githubusercontent.com/assets/21558765/22850750/4a29bf6e-f035-11e6-9c56-cb222f676483.png)

Web : 

![web](https://cloud.githubusercontent.com/assets/21558765/22850775/c0d27fb6-f035-11e6-877d-d2fa721687c5.jpg)





- [x] Code is formatted.

- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] If new feature is implemeted then it is compatible with Night theme too.

- [x] Commit messages are well-written.
