### PR TITLE
Removed "/api" from server url after logout

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -2123,7 +2123,7 @@ public class ZulipActivity extends BaseActivity implements
     private void logout() {
         commonProgressDialog.showWithMessage(getString(R.string.logging_out));
         this.logged_in = false;
-        final String serverUrl = app.getServerURI();
+        final String serverUrl = app.getServerHostUri() ;
 
         notifications.logOut(new Runnable() {
             public void run() {


### PR DESCRIPTION
Fixes #375 .

Now the sever url does not contain **/api** after logout.

![g_20170213_0303283](https://cloud.githubusercontent.com/assets/13676490/22866259/4a0361b0-f199-11e6-9299-7f38c7973fbc.gif)
