### PR TITLE
Stop fabric crashlytics initialization on app start if on DEBUG.

### DIFF
--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -126,7 +126,8 @@ public class ZulipApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        Fabric.with(this, new Crashlytics());
+        if (!BuildConfig.DEBUG)
+            Fabric.with(this, new Crashlytics());
         ZulipApp.setInstance(this);
 
         // This used to be from HumbugActivity.getPreferences, so we keep that

--- a/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
+++ b/app/src/main/java/com/zulip/android/networking/ZulipAsyncPushTask.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
+import com.zulip.android.BuildConfig;
 import com.zulip.android.ZulipApp;
 import com.zulip.android.util.ZLog;
 
@@ -76,7 +77,8 @@ public abstract class ZulipAsyncPushTask extends AsyncTask<String, String, Strin
     }
 
     protected String doInBackground(String... api_path) {
-        Crashlytics.log(Log.VERBOSE, "Network call", getClass().getCanonicalName() + request);
+        if (!BuildConfig.DEBUG)
+            Crashlytics.log(Log.VERBOSE, "Network call", getClass().getCanonicalName() + request);
 
         try {
             Response response = request.execute();


### PR DESCRIPTION
**Summary of changes**

Removed the initialization of crashlytics if on DEBUG, as the debug don't have the keys for the fabric, hence error was thrown! 

Please make sure these boxes are checked before submitting your pull request - thanks! [Guide](./PULL_REQUEST_GUIDE.md)

- [x] Code is formatted.

- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] If new feature is implemeted then it is compatible with Night theme too.

- [x] Commit messages are well-written.
