### PR TITLE
Fetch raw message content before editing

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -485,9 +485,7 @@ public class MessageListFragment extends Fragment implements MessageListener {
                             @Override
                             public void onResponse(Call<EditResponse> call, Response<EditResponse> response) {
                                 if (response.isSuccessful()) {
-                                    message.setContent(editedMessageContent);
-                                    message.setFormattedContent(editedMessageContent);
-                                    adapter.notifyItemChanged(position);
+                                    //The message editing work in the list will be done by the AsyncGetEvents#processUpdateMessages
                                     progress.dismiss();
                                     Toast.makeText(getActivity(), R.string.message_edited, Toast.LENGTH_SHORT).show();
                                 } else {

--- a/app/src/main/java/com/zulip/android/networking/response/RawMessageResponse.java
+++ b/app/src/main/java/com/zulip/android/networking/response/RawMessageResponse.java
@@ -1,0 +1,33 @@
+package com.zulip.android.networking.response;
+
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Used for fetching the raw content of any message (in markdown format)
+ * <p>
+ * example : {"msg":"","result":"success","raw_content":":+1: texthere\n"}
+ */
+public class RawMessageResponse {
+
+    @SerializedName("msg")
+    private String msg;
+
+    @SerializedName("result")
+    private String result;
+
+    @SerializedName("raw_content")
+    private String rawContent;
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public String getRawContent() {
+        return rawContent;
+    }
+}

--- a/app/src/main/java/com/zulip/android/service/ZulipServices.java
+++ b/app/src/main/java/com/zulip/android/service/ZulipServices.java
@@ -4,6 +4,7 @@ import com.zulip.android.filters.NarrowFilter;
 import com.zulip.android.networking.response.EditResponse;
 import com.zulip.android.networking.response.GetMessagesResponse;
 import com.zulip.android.networking.response.LoginResponse;
+import com.zulip.android.networking.response.RawMessageResponse;
 import com.zulip.android.networking.response.UploadResponse;
 import com.zulip.android.networking.response.UserConfigurationResponse;
 import com.zulip.android.networking.response.ZulipBackendResponse;
@@ -65,4 +66,7 @@ public interface ZulipServices {
     @FormUrlEncoded
     @PATCH("v1/messages/{id}")
     Call<EditResponse> editMessage(@Path("id") String messageId, @Field("content") String messageContent);
+
+    @GET("v1/messages/{id}")
+    Call<RawMessageResponse> fetchRawMessage(@Path("id") int messageId);
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,4 +153,6 @@
     <string name="logging_out">Logging out</string>
     <string name="fetch_edit_message">Preparing Message for edit</string>
     <string name="no_edit">No edits detected</string>
+    <string name="copy_message_fetch">Copying message to clipboard</string>
+    <string name="copy_failed">Copying to clipboard failed</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,4 +151,6 @@
     <string name="connecting_to_server">Connecting to server</string>
     <string name="refreshing">Refreshing</string>
     <string name="logging_out">Logging out</string>
+    <string name="fetch_edit_message">Preparing Message for edit</string>
+    <string name="no_edit">No edits detected</string>
 </resources>


### PR DESCRIPTION
**Summary of changes**

[Explain here what changes were made and why.]


This now fetches the raw message before editing to save the formatted content (like emojis, mention @) 

Still one thing can be noticed after edit is successful, the updated raw content is displayed instead of the formatted content, but after list reload it start's showing fine. 

I'll update the PR if I find solution for this! 


Please make sure these boxes are checked before submitting your pull request - thanks! [Guide](./PULL_REQUEST_GUIDE.md)

- [x] Code is formatted.

- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] If new feature is implemeted then it is compatible with Night theme too.

- [x]  Commit messages are well-written.
