### PR TITLE
Fix: Crash on context menu item selected when fragment replaced.

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
+++ b/app/src/main/java/com/zulip/android/activities/MessageListFragment.java
@@ -202,7 +202,14 @@ public class MessageListFragment extends Fragment implements MessageListener {
 
     @Override
     public boolean onContextItemSelected(MenuItem item) {
-        Message message = (Message) adapter.getItem(adapter.getContextMenuItemSelectedPosition());
+        // fragment replace transaction can be committed during long press on a message
+        int position = adapter.getContextMenuItemSelectedPosition();
+        if (position == RecyclerView.NO_POSITION) {
+            Toast.makeText(getContext(), R.string.try_again_error_msg, Toast.LENGTH_SHORT).show();
+            return false;
+        }
+
+        Message message = (Message) adapter.getItem(position);
         switch (item.getItemId()) {
             case R.id.reply_to_stream:
                 ((NarrowListener) getActivity()).onNarrowFillSendBox(message, true);

--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -86,7 +86,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     @ColorInt
     private int privateMessageBackground;
     private OnItemClickListener onItemClickListener;
-    private int contextMenuItemSelectedPosition;
+    private int contextMenuItemSelectedPosition = RecyclerView.NO_POSITION;
     private View footerView;
     private View headerView;
     private UpdateBuilder<Message, Object> updateBuilder;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,4 +155,5 @@
     <string name="no_edit">No edits detected</string>
     <string name="copy_message_fetch">Copying message to clipboard</string>
     <string name="copy_failed">Copying to clipboard failed</string>
+    <string name="try_again_error_msg">Something went wrong, try again</string>
 </resources>


### PR DESCRIPTION
When a message with a clickable span is long pressed, the user can accidentally long press on the span itself, which can cause a fragment replace transaction and contextmenu generation at the same time. On selecting any of the options of menu the app crashes. Actually this bug is also in v1.1.2
Added a check for this.