### PR TITLE
Fix: Use Patterns.WEB_URL to check if url valid or not.

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -19,7 +19,6 @@ import android.util.Log;
 import android.util.Patterns;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.webkit.URLUtil;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -41,8 +40,8 @@ import com.zulip.android.networking.response.ZulipBackendResponse;
 import com.zulip.android.networking.util.DefaultCallback;
 import com.zulip.android.util.ActivityTransitionAnim;
 import com.zulip.android.util.AnimationHelper;
-import com.zulip.android.util.Constants;
 import com.zulip.android.util.CommonProgressDialog;
+import com.zulip.android.util.Constants;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -263,10 +262,10 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
 
     private boolean isUrlValid(String url) {
         if (BuildConfig.DEBUG) {
-            return URLUtil.isValidUrl(String.valueOf(url)) ||
+            return Patterns.WEB_URL.matcher(String.valueOf(url)).matches() ||
                     Patterns.IP_ADDRESS.matcher(url).matches();
         } else {
-            return URLUtil.isValidUrl(String.valueOf(url));
+            return Patterns.WEB_URL.matcher(String.valueOf(url)).matches();
         }
     }
 

--- a/app/src/main/java/com/zulip/android/activities/LoginActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/LoginActivity.java
@@ -278,6 +278,7 @@ public class LoginActivity extends BaseActivity implements View.OnClickListener,
 
         if (!isUrlValid(serverURL)) {
             Toast.makeText(LoginActivity.this, R.string.invalid_url, Toast.LENGTH_SHORT).show();
+            commonProgressDialog.dismiss();
             return;
         }
 


### PR DESCRIPTION
So `URLUtil.isValidUrl` isn't the best method to check validity of url since it returns true for addresses like "https://something  and.com".

Used `Patterns.WEB_URL` instead. This bug too has been in v1.1.2