### PR TITLE
Fixed word wrapping of text in <pre> tags using CSS in legal.html

### DIFF
--- a/app/src/main/assets/legal.html
+++ b/app/src/main/assets/legal.html
@@ -3,6 +3,12 @@
 <head>
     <title>Zulip Legal Information</title>
     <meta charset="UTF-8">
+    <style>
+        pre {
+            white-space: pre-wrap;
+            word-wrap: break-word;
+        }
+    </style>
 </head>
 <body>
 <h1>Zulip for Android</h1>


### PR DESCRIPTION
**Summary of changes**
Very small fix:
Added word-wrapping CSS for pre tags in legal.html to avoid the very long blocks of legal information in the WebView that went off the screen and required lots of scrolling.
(This is my first ever pull-request/contribution to open source so please tell me if I am doing anything wrong!)

Screenshots or a brief video showing the change in action:
**Before**:
![screenshot_20170302-140040](https://cloud.githubusercontent.com/assets/11599574/23529270/388d9b2a-ff5a-11e6-9a6f-df8a298a3fb8.png)

**After**:
![screenshot_20170302-140154](https://cloud.githubusercontent.com/assets/11599574/23529335/763d3714-ff5a-11e6-8314-a020cd219ce3.png)



Please make sure these boxes are checked before submitting your pull request - thanks! [Guide](./PULL_REQUEST_GUIDE.md)

- [x] Code is formatted.

- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] If new feature is implemeted then it is compatible with Night theme too.

- [x] Commit messages are well-written.
