### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ Another way to connect android device to local server is via adb
 
 -  Run ``adb reverse tcp:9991 tcp:9991`` in terminal
 
--  Connect to local server by entering url (**http://127.0.0.0.1:9991**) in app
+-  Connect to local server by entering url (**http://127.0.0.1:9991**) in app
 
 .. _here: https://github.com/zulip/zulip/blob/1c40df9363b70af0e275c44a03f9627808852616/Vagrantfile#L37
 .. _Host Remapping: http://docs.telerik.com/fiddler/KnowledgeBase/HOSTS


### PR DESCRIPTION
There is typo mistake in README.rst file at Connect android device to local server via adb
(https://github.com/zulip/zulip-android#connecting-to-a-development-server). 

Where server URL is http://127.0.0.0.1:9991 which is invalid

I changed URL to http://127.0.0.1:9991

