### PR TITLE
Upgrade to Gradle 2.3, fix zulip/zulip-android#467.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.google.gms:google-services:2.1.0'
     }
 }


### PR DESCRIPTION
We needed to upgrade to Gradle 2.3 for better functionality.