### PR TITLE
Fixed topic indicator/separator showing for new messages when user has the topic open

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
+++ b/app/src/main/java/com/zulip/android/activities/RecyclerMessageAdapter.java
@@ -289,7 +289,7 @@ public class RecyclerMessageAdapter extends RecyclerView.Adapter<RecyclerView.Vi
      */
     public void addNewMessage(Message message) {
         MessageHeaderParent item = null;
-        for (int i = getItemCount(false) - 1; i > 1; i--) {
+        for (int i = getItemCount(false) - 1; i >= 1; i--) {
             //Find the last header and check if it belongs to this message!
             if (items.get(i) instanceof MessageHeaderParent) {
                 item = (MessageHeaderParent) items.get(i);


### PR DESCRIPTION
Fixes #441

**Summary of changes**

The for loop in `addNewMessage()` in `RecyclerMessageAdapter.java` goes from `getItemCount(false)` to 1, but not equal to 1. When the user has opened a topic, the only `MessageHeaderParent` in the list is at the top of the list of items. When i does not go to 1, the `if(items.get(i) instanceof MessageHeaderParent)` never gets executed. This means `item` remains null and `if(item == null)` block is executed, resulting in the creation of the `MessageHeaderParent` above the new message, which is not wanted.

By making it `i >= 1`, the `MessageHeaderParent` at the top of the list is also included.


Please make sure these boxes are checked before submitting your pull request - thanks! [Guide](./PULL_REQUEST_GUIDE.md)

- [X] Code is formatted.

- [X] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [X] If new feature is implemeted then it is compatible with Night theme too.

- [X] Commit messages are well-written.
