### PR TITLE
Fixes #503: Fix the camera opening on clicking the notification

### DIFF
--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -141,6 +141,7 @@ import okhttp3.MultipartBody;
 import retrofit2.Call;
 import retrofit2.Response;
 
+import static com.zulip.android.util.Constants.ACTION_MESSAGE_PUSH_NOTIFICATION;
 import static com.zulip.android.util.Constants.REQUEST_PICK_FILE;
 
 /**
@@ -879,6 +880,9 @@ public class ZulipActivity extends BaseActivity implements
                 // Handle single file being sent
                 handleSentFile((Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM));
             }
+        } else if (ACTION_MESSAGE_PUSH_NOTIFICATION.equals(action)) {
+            // Here, this condition can be used if some data has to be passed from the message push notification
+            return; // We don't want to do with the data right so, do this return and skip the other check
         }
 
         // extract file path of edited image

--- a/app/src/main/java/com/zulip/android/gcm/GcmIntentService.java
+++ b/app/src/main/java/com/zulip/android/gcm/GcmIntentService.java
@@ -18,6 +18,8 @@ import com.zulip.android.util.ZLog;
 import java.io.IOException;
 import java.net.URL;
 
+import static com.zulip.android.util.Constants.ACTION_MESSAGE_PUSH_NOTIFICATION;
+
 /**
  * This {@code IntentService} does the actual handling of the GCM message.
  * {@code GcmBroadcastReceiver} (a {@code WakefulBroadcastReceiver}) holds a
@@ -48,7 +50,7 @@ public class GcmIntentService extends IntentService {
                 .getSystemService(Context.NOTIFICATION_SERVICE);
 
         PendingIntent contentIntent = PendingIntent.getActivity(this, 0,
-                new Intent(this, ZulipActivity.class).addFlags(0), 0);
+                new Intent(this, ZulipActivity.class).addFlags(0).setAction(ACTION_MESSAGE_PUSH_NOTIFICATION), 0);
 
         String type = msg.getString("recipient_type");
         String tag = "zulip";

--- a/app/src/main/java/com/zulip/android/util/Constants.java
+++ b/app/src/main/java/com/zulip/android/util/Constants.java
@@ -26,4 +26,5 @@ public class Constants {
     public static String END_POINT_REGISTER = "register";
     //if two continuous messages are from same sender and time difference is less than this then hide it
     public static long HIDE_TIMESTAMP_THRESHOLD = 60 * 1000;// 1 minute
+    public static String ACTION_MESSAGE_PUSH_NOTIFICATION = "ACTION_MESSAGE_PUSH_NOTIFICATION";
 }


### PR DESCRIPTION
So it seems the action in the intent from the notification has the action as null and its going to `dispatchTakePictureIntent();` as the filepath will be null as well, so the camera app is opening on pressing notification! 