### PR TITLE
Restore theme after closing/reopening the app.

### DIFF
--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -598,4 +598,15 @@ public class ZulipApp extends Application {
             }
         }
     }
+
+    /**
+     * Update preferred theme
+     * @param b true if night theme is preferred
+     */
+    public void makeNightThemeDefault(boolean nightTheme) {
+        SharedPreferences.Editor editor = getSettings().edit();
+
+        editor.putBoolean(Constants.NIGHT_THEME, nightTheme);
+        editor.apply();
+    }
 }

--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -604,6 +604,7 @@ public class ZulipApp extends Application {
 
     /**
      * Update preferred theme
+     *
      * @param b true if night theme is preferred
      */
     public void makeNightThemeDefault(boolean nightTheme) {
@@ -615,6 +616,7 @@ public class ZulipApp extends Application {
 
     /**
      * update auto night theme preference
+     *
      * @param value preference value
      */
     public void setAutoNightTheme(boolean value) {

--- a/app/src/main/java/com/zulip/android/ZulipApp.java
+++ b/app/src/main/java/com/zulip/android/ZulipApp.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences.Editor;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Handler;
+import android.support.v7.app.AppCompatDelegate;
 import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
@@ -135,11 +136,13 @@ public class ZulipApp extends Application {
         if (!BuildConfig.DEBUG)
             Fabric.with(this, new Crashlytics());
         ZulipApp.setInstance(this);
-
         // This used to be from HumbugActivity.getPreferences, so we keep that
         // file name.
         this.settings = getSharedPreferences("HumbugActivity", Context.MODE_PRIVATE);
-
+        //check for auto theme is enabled or not
+        if (getSettings().getBoolean(Constants.AUTO_NIGHT_THEME, false)) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+        }
         max_message_id = settings.getInt("max_message_id", -1);
         eventQueueId = settings.getString("eventQueueId", null);
         lastEventId = settings.getInt("lastEventId", -1);
@@ -607,6 +610,17 @@ public class ZulipApp extends Application {
         SharedPreferences.Editor editor = getSettings().edit();
 
         editor.putBoolean(Constants.NIGHT_THEME, nightTheme);
+        editor.apply();
+    }
+
+    /**
+     * update auto night theme preference
+     * @param value preference value
+     */
+    public void setAutoNightTheme(boolean value) {
+        SharedPreferences.Editor editor = getSettings().edit();
+
+        editor.putBoolean(Constants.AUTO_NIGHT_THEME, value);
         editor.apply();
     }
 }

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -2259,8 +2259,13 @@ public class ZulipActivity extends BaseActivity implements
             getMenuInflater().inflate(R.menu.options, menu);
             prepareSearchView(menu);
             this.menu = menu;
-            menu.findItem(R.id.autoTheme).setChecked(app.getSettings()
-                    .getBoolean(Constants.AUTO_NIGHT_THEME, false));
+            if (app.getSettings().getBoolean(Constants.AUTO_NIGHT_THEME, false)) {
+                menu.findItem(R.id.autoTheme).setChecked(true);
+            } else if (app.getSettings().getBoolean(Constants.NIGHT_THEME, false)) {
+                menu.findItem(R.id.nightTheme).setChecked(true);
+            } else {
+                menu.findItem(R.id.dayTheme).setChecked(true);
+            }
             return true;
         }
 
@@ -2363,17 +2368,22 @@ public class ZulipActivity extends BaseActivity implements
             case R.id.private_msg:
                 drawerLayout.openDrawer(GravityCompat.END);
                 break;
-            case R.id.daynight:
-                switch (AppCompatDelegate.getDefaultNightMode()) {
-                    case -1:
-                    case AppCompatDelegate.MODE_NIGHT_NO:
-                        setNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-                        app.makeNightThemeDefault(true);
-                        break;
-                    default:
-                        setNightMode(AppCompatDelegate.MODE_NIGHT_NO);
-                        app.makeNightThemeDefault(false);
-                        break;
+            case R.id.dayTheme:
+                item.setChecked(!item.isChecked());
+                if (item.isChecked() &&
+                        AppCompatDelegate.getDefaultNightMode() != AppCompatDelegate.MODE_NIGHT_NO) {
+                    setNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+                    app.makeNightThemeDefault(false);
+                    app.setAutoNightTheme(false);
+                }
+                break;
+            case R.id.nightTheme:
+                item.setChecked(!item.isChecked());
+                if (item.isChecked() &&
+                        AppCompatDelegate.getDefaultNightMode() != AppCompatDelegate.MODE_NIGHT_YES) {
+                    setNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+                    app.makeNightThemeDefault(true);
+                    app.setAutoNightTheme(false);
                 }
                 break;
             case R.id.autoTheme:

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -354,6 +354,13 @@ public class ZulipActivity extends BaseActivity implements
             mMutedTopics = MutedTopics.get();
         }
 
+        boolean isCurrentThemeNight = (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES);
+
+        //apply preferred theme
+       if (app.getSettings().getBoolean(Constants.NIGHT_THEME, false) && !isCurrentThemeNight) {
+            setNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+        }
+
         this.logged_in = true;
         notifications = new Notifications(this);
         notifications.register();
@@ -386,7 +393,7 @@ public class ZulipActivity extends BaseActivity implements
         sendBtn = (ImageView) findViewById(R.id.send_btn);
         addFileBtn = (ImageView) findViewById(R.id.add_btn);
         appBarLayout = (AppBarLayout) findViewById(R.id.appBarLayout);
-        boolean isCurrentThemeNight = (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES);
+
         etSearchPeople = (EditText) findViewById(R.id.people_drawer_search);
         ivSearchPeopleCancel = (ImageView) findViewById(R.id.iv_people__search_cancel_button);
         onTextChangeOfPeopleSearchEditText();
@@ -2358,12 +2365,11 @@ public class ZulipActivity extends BaseActivity implements
                     case -1:
                     case AppCompatDelegate.MODE_NIGHT_NO:
                         setNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-                        break;
-                    case AppCompatDelegate.MODE_NIGHT_YES:
-                        setNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+                        app.makeNightThemeDefault(true);
                         break;
                     default:
                         setNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+                        app.makeNightThemeDefault(false);
                         break;
                 }
                 break;

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -357,8 +357,8 @@ public class ZulipActivity extends BaseActivity implements
         boolean isCurrentThemeNight = (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES);
 
         //apply preferred theme
-       if (app.getSettings().getBoolean(Constants.NIGHT_THEME, false) && !isCurrentThemeNight
-               && !app.getSettings().getBoolean(Constants.AUTO_NIGHT_THEME,false)) {
+        if (app.getSettings().getBoolean(Constants.NIGHT_THEME, false) && !isCurrentThemeNight
+                && !app.getSettings().getBoolean(Constants.AUTO_NIGHT_THEME, false)) {
             setNightMode(AppCompatDelegate.MODE_NIGHT_YES);
         }
 
@@ -2260,7 +2260,7 @@ public class ZulipActivity extends BaseActivity implements
             prepareSearchView(menu);
             this.menu = menu;
             menu.findItem(R.id.autoTheme).setChecked(app.getSettings()
-                    .getBoolean(Constants.AUTO_NIGHT_THEME,false));
+                    .getBoolean(Constants.AUTO_NIGHT_THEME, false));
             return true;
         }
 
@@ -2421,12 +2421,12 @@ public class ZulipActivity extends BaseActivity implements
                 alertDialog.setMessage(getString(R.string.logout_title));
                 alertDialog.setPositiveButton(getString(android.R.string.yes), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int which) {
-                    logout();
+                        logout();
                     }
                 });
                 alertDialog.setNegativeButton(getString(android.R.string.no), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int which) {
-                    dialog.cancel();
+                        dialog.cancel();
                     }
                 });
                 alertDialog.show();
@@ -2717,6 +2717,7 @@ public class ZulipActivity extends BaseActivity implements
     /**
      * Store floating message header
      * useful when message list get's scrolled
+     *
      * @param viewHolder floating message header
      */
     public void setViewHolder(RecyclerView.ViewHolder viewHolder) {

--- a/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
+++ b/app/src/main/java/com/zulip/android/activities/ZulipActivity.java
@@ -357,7 +357,8 @@ public class ZulipActivity extends BaseActivity implements
         boolean isCurrentThemeNight = (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES);
 
         //apply preferred theme
-       if (app.getSettings().getBoolean(Constants.NIGHT_THEME, false) && !isCurrentThemeNight) {
+       if (app.getSettings().getBoolean(Constants.NIGHT_THEME, false) && !isCurrentThemeNight
+               && !app.getSettings().getBoolean(Constants.AUTO_NIGHT_THEME,false)) {
             setNightMode(AppCompatDelegate.MODE_NIGHT_YES);
         }
 
@@ -2258,6 +2259,8 @@ public class ZulipActivity extends BaseActivity implements
             getMenuInflater().inflate(R.menu.options, menu);
             prepareSearchView(menu);
             this.menu = menu;
+            menu.findItem(R.id.autoTheme).setChecked(app.getSettings()
+                    .getBoolean(Constants.AUTO_NIGHT_THEME,false));
             return true;
         }
 
@@ -2371,6 +2374,13 @@ public class ZulipActivity extends BaseActivity implements
                         setNightMode(AppCompatDelegate.MODE_NIGHT_NO);
                         app.makeNightThemeDefault(false);
                         break;
+                }
+                break;
+            case R.id.autoTheme:
+                item.setChecked(!item.isChecked());
+                app.setAutoNightTheme(item.isChecked());
+                if (item.isChecked()) {
+                    setNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
                 }
                 break;
             case R.id.refresh:

--- a/app/src/main/java/com/zulip/android/util/Constants.java
+++ b/app/src/main/java/com/zulip/android/util/Constants.java
@@ -28,4 +28,5 @@ public class Constants {
     public static long HIDE_TIMESTAMP_THRESHOLD = 60 * 1000;// 1 minute
     public static String ACTION_MESSAGE_PUSH_NOTIFICATION = "ACTION_MESSAGE_PUSH_NOTIFICATION";
     public static String NIGHT_THEME = "NIGHT_THEME";
+    public static String AUTO_NIGHT_THEME = "AUTO_NIGHT_THEME";
 }

--- a/app/src/main/java/com/zulip/android/util/Constants.java
+++ b/app/src/main/java/com/zulip/android/util/Constants.java
@@ -27,4 +27,5 @@ public class Constants {
     //if two continuous messages are from same sender and time difference is less than this then hide it
     public static long HIDE_TIMESTAMP_THRESHOLD = 60 * 1000;// 1 minute
     public static String ACTION_MESSAGE_PUSH_NOTIFICATION = "ACTION_MESSAGE_PUSH_NOTIFICATION";
+    public static String NIGHT_THEME = "NIGHT_THEME";
 }

--- a/app/src/main/res/menu/options.xml
+++ b/app/src/main/res/menu/options.xml
@@ -38,14 +38,19 @@
         android:id="@+id/theme"
         android:title="@string/theme">
         <menu>
-            <item
-                android:id="@+id/daynight"
-                android:title="@string/switch_theme" />
-            <item
-                android:id="@+id/autoTheme"
-                android:checkable="true"
-                android:title="@string/autoTheme"
-                app:actionViewClass="android.widget.CheckBox" />
+            <group
+                android:id="@+id/group"
+                android:checkableBehavior="single">
+                <item
+                    android:id="@+id/dayTheme"
+                    android:title="@string/dayTheme" />
+                <item
+                    android:id="@+id/nightTheme"
+                    android:title="@string/nightTheme" />
+                <item
+                    android:id="@+id/autoTheme"
+                    android:title="@string/autoTheme" />
+            </group>
         </menu>
     </item>
 

--- a/app/src/main/res/menu/options.xml
+++ b/app/src/main/res/menu/options.xml
@@ -35,8 +35,20 @@
     </item>
 
     <item
-        android:id="@+id/daynight"
-        android:title="@string/switch_theme" />
+        android:id="@+id/theme"
+        android:title="@string/theme">
+        <menu>
+            <item
+                android:id="@+id/daynight"
+                android:title="@string/switch_theme" />
+            <item
+                android:id="@+id/autoTheme"
+                android:checkable="true"
+                android:title="@string/autoTheme"
+                app:actionViewClass="android.widget.CheckBox" />
+        </menu>
+    </item>
+
     <item
         android:id="@+id/isStarred"
         android:title="@string/starred_messages" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,4 +182,6 @@
     <string name="placeholder_social">Social</string>
     <!--Placeholder strings-->
     <string name="terms">Terms Of Service</string>
+    <string name="autoTheme">Auto Night Theme</string>
+    <string name="theme">Theme</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,8 +181,8 @@
     <string name="placeholder_social">Social</string>
     <!--Placeholder strings-->
     <string name="terms">Terms Of Service</string>
-    <string name="autoTheme">Auto Night Theme</string>
+    <string name="autoTheme">Auto</string>
     <string name="theme">Theme</string>
-    <string name="nightTheme">Night Theme</string>
-    <string name="dayTheme">Day Theme</string>
+    <string name="nightTheme">Night</string>
+    <string name="dayTheme">Day</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,7 +84,6 @@
     <string name="use_https">Use HTTPS</string>
     <string name="use_http">Use HTTP</string>
     <string name="empty_list">Sorry, no messages here.</string>
-    <string name="switch_theme">Switch day/night theme</string>
     <string name="reply_stream">Reply to stream</string>
     <string name="reply_sender">Reply to sender</string>
     <string name="narrow_stream">Narrow to this stream</string>
@@ -184,4 +183,6 @@
     <string name="terms">Terms Of Service</string>
     <string name="autoTheme">Auto Night Theme</string>
     <string name="theme">Theme</string>
+    <string name="nightTheme">Night Theme</string>
+    <string name="dayTheme">Day Theme</string>
 </resources>


### PR DESCRIPTION
Fix:#505

**Summary of changes**

Save preferred theme in Shared Preferences. And restore them on reopening app.

Screenshots or a brief video showing the change in action:

![ezgif com-video-to-gif-2](https://cloud.githubusercontent.com/assets/18511177/26751891/903097a6-4861-11e7-9389-8bca910bdd0d.gif)

Please make sure these boxes are checked before submitting your pull request - thanks! [Guide](./PULL_REQUEST_GUIDE.md)

- [x] Code is formatted.

- [x] Run the lint tests with `./gradlew lintDebug` and make sure BUILD is SUCCESSFUL

- [x] If new feature is implemeted then it is compatible with Night theme too.

- [x] Commit messages are well-written.