### PR TITLE
Improve strings.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="password">Password</string>
     <string name="server_url">Server URL</string>
     <string name="server_domain">Server domain</string>
-    <string name="privacy">Privacy Policy</string>
+    <string name="privacy">Privacy policy</string>
     <string name="logout">Log out</string>
     <string name="force_logged_out">You\'ve been logged out</string>
     <string name="huddle_text">You</string>
@@ -142,7 +142,7 @@
     <string name="notify_private" formatted="false">from %1$s</string>
     <string name="today_messages">Today\'s messages</string>
     <string name="messages">Messages</string>
-    <string name="starred_messages">Starred Messages</string>
+    <string name="starred_messages">Starred messages</string>
     <plurals name="new_message_mul_sender">
         <item quantity="one">%d new message</item>
         <item quantity="other">%d new messages</item>
@@ -171,15 +171,15 @@
     <string name="upload_started_str">Upload started</string>
     <string name="cancel">Cancel</string>
     <string name="no_message_to_display">Sorry, no messages to display!</string>
-    <string name="crop">CROP</string>
+    <string name="crop">Crop</string>
     <string name="logout_title">Are you sure you want to logout?</string>
     <!--Placeholder strings-->
     <string name="placeholder_my_stream">MyStream</string>
-    <string name="placeholder_short_stream">Short Stream</string>
+    <string name="placeholder_short_stream">Short stream</string>
     <string name="placeholder_topic">Topic</string>
     <string name="placeholder_message_here">Message here</string>
     <string name="placeholder_sender_name">Sender name</string>
     <string name="placeholder_social">Social</string>
     <!--Placeholder strings-->
-    <string name="terms">Terms Of Service</string>
+    <string name="terms">Terms of Service</string>
 </resources>


### PR DESCRIPTION
**Summary of changes**

Strings in `strings.xml` have been properly capitalized, following the convention in #405.

"Terms of Service" has been left with "Service" capitalized, as many other services do (like [Google's TOS](https://www.google.com/accounts/TOS)).

**Other considerations**

I'd suggest that someone more familiar with the app's codebase reviewed:

- `<string name="link_image">ImageView of link</string>`
- `<string name="crop">CROP</string>`
- `<string name="placeholder_my_stream">MyStream</string>`

As those seem to be strings that cannot be changed without some modifications to the code that uses them. The first and the third one shouldn't be translated (or at least in that form).
